### PR TITLE
support for dbt docs 

### DIFF
--- a/dbt/include/impala/macros/catalog.sql
+++ b/dbt/include/impala/macros/catalog.sql
@@ -13,12 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #}
- 
+
 {% macro impala__get_catalog(information_schema, schemas) -%}
 
-  {% set msg -%}
-    get_catalog not implemented for impala
-  {%- endset %}
-
-  {{ exceptions.raise_compiler_error(msg) }}
+  {# no-op #}
 {% endmacro %}
+ 


### PR DESCRIPTION
support for dbt docs and implementation of get_catalogs macro which is needed for docs generation

(Internal Ticket) : https://jira.cloudera.com/browse/DBT-63

Testplan:
            1. Basic dependencies need to be installed. These are mentioned in README.md
            2. Build and install the dbt-impala adapter using:
                   python3 setup.py install

            3. Create a template dbt project using following:
                   dbt init

            4. Edit $HOME/.dbt/profiles.yml so that it looks similar to:

                   demo_dbt:
                     outputs:

                       dev_impala:
                         type: impala
                         host: localhost
                         port: 21050
                         dbname: s3test
                         schema: s3test

                     target: dev_impala

            5. In the dbt project generated in step (2), run the following, which should succeed if local instance of Impala is up:
                    dbt debug (check connection)

            6. Generate docs:
                    dbt docs generate (generate the docs)
                    dbt docs serve (this will open generated docs in a browser)