### PR TITLE
remove pinned dependency of dbt-core==1.0.1 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     packages=find_namespace_packages(include=['dbt', 'dbt.*']),
     include_package_data=True,
     install_requires=[
-        "dbt-core==1.0.1",
+        "dbt-core~=1.0.1",
         "impyla"
     ],
     classifiers=[


### PR DESCRIPTION
remove pinned dependency of dbt-core==1.0.1 in setup.py
Testplan:
 1. Update dbt-core dependency to 1.0.4 (pip3 install --upgrade dbt-core), the current release version
 2. From a dbt_demo project (https://github.infra.cloudera.com/abrown/dbt_demo) check:
      dbt debug (connection)
      dbt seed (seeds)
      dbt run (models)
      dbt docs generate (generate docs)
      dbt docs serve (start a browser with generated docs)
 3. All commands should execute without error
 4. Optional:
      dbt tests (this will check if dbt tests is running)
