### PR TITLE
kerberos support for connecting to impala instance

### DIFF
--- a/dbt/adapters/impala/connections.py
+++ b/dbt/adapters/impala/connections.py
@@ -44,6 +44,7 @@ class ImpalaCredentials(Credentials):
     schema: str
     database: str
     auth_type: Optional[str] = None
+    kerberos_service_name: Optional[str] = None
     use_http_transport: Optional[bool] = True
     use_ssl: Optional[bool] = True
     http_path: Optional[str] = ''  # for supporing a knox proxy in ldap env
@@ -102,6 +103,15 @@ class ImpalaConnectionManager(SQLConnectionManager):
                     password=credentials.password,
                     use_ssl=credentials.use_ssl,
                     http_path=credentials.http_path
+                )
+            elif (credentials.auth_type == "GSSAPI" or credentials.auth_type == "gssapi" or credentials.auth_type == "kerberos"): # kerberos based connection
+                handle = impala.dbapi.connect(
+                    host=credentials.host,
+                    port=credentials.port,
+                    auth_mechanism='GSSAPI',
+                    kerberos_service_name=credentials.kerberos_service_name,
+                    use_http_transport=credentials.use_http_transport,
+                    use_ssl=credentials.use_ssl
                 )
             else: # default, insecure connection
                 handle = impala.dbapi.connect(


### PR DESCRIPTION
(Internal Ticket): https://jira.cloudera.com/browse/DBT-21

Testplan:
        1. Basic dependencies need to be installed. These are mentioned in README.md
        2. Build and install the dbt-impala adapter using:
               python3 setup.py install

        3. Create a template dbt project using following:
               dbt init

        4. Ensure kerberos is initilized and relevant libraries properly installed - depending on your OS

        5. Edit $HOME/.dbt/profiles.yml so that it looks similar to:

               demo_dbt:
                 outputs:

                   dev_impala_kerberos:
                     type: impala
                     host: <hostname>
                     port: <port>
                     auth_type: GSSAPI
                     kerberos_service_name: <kerberos service name>
                     use_http_transport: true
                     use_ssl: true
                     dbname: s3test
                     schema: s3test

                 target: dev_impala_kerberos

         6. In the dbt project generated in step (2), run the following, which should succeed if local instance of Impala is up:
                 dbt debug (check connection)