### PR TITLE
support EXTERNAL clause with table materialization

### DIFF
--- a/dbt/include/impala/macros/adapters.sql
+++ b/dbt/include/impala/macros/adapters.sql
@@ -141,10 +141,11 @@
 
   {%- set sql_header = config.get('sql_header', none) -%}
   {%- set backup = config.get('backup') -%}
+  {%- set is_external = config.get('external') -%}
 
   {{ sql_header if sql_header is not none }}
 
-  create table
+  create {% if is_external == true -%}external{%- endif %} table
     {{ relation.include(schema=true) }}
     {% if backup == false -%}backup no{%- endif %}
     {{ ct_option_partition_cols(label="partitioned by") }}


### PR DESCRIPTION
Internal Ticket: https://jira.cloudera.com/browse/DBT-75

Testplan:
1. Basic dependencies need to be installed. These are mentioned in README.txt
2. Build and install the dbt-impala adapter using:
       python3 setup.py install

3. Create a template dbt project using following:
       dbt init

4. Edit $HOME/.dbt/profiles.yml so that it looks similar to:

       demo_dbt:
         outputs:

           dev_impala:
             type: impala
             host: localhost
             port: 21050
             dbname: s3test
             schema: s3test

         target: dev_impala

5. In the dbt project generated in step (2), run the following, which should succeed if local instance of Impala is up:
        dbt debug (check connection)

6. Write a model similar to:
  {{
     config(
        materialized='table',
        external=true
     )
  }}

select * from {{ source('s3test', 'census') }}

The config option external=true creates an external table.

To run the model use:
   dbt run

You will get an output similar to:
13:37:45  1 of 1 OK created table model s3test.my_external_model........................... [OK in 57.75s]
13:37:45
13:37:45  Finished running 1 table model in 57.85s.
13:37:45
13:37:45  Completed successfully
13:37:45
13:37:45  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1

7. You can describe the table from shell to verify creation:
show create table my_external_model;
Query: show create table my_external_model
+-------------------------------------------------------------------------------------------+
| result                                                                                    |
+-------------------------------------------------------------------------------------------+
| CREATE EXTERNAL TABLE s3test.my_external_model (                                          |
|   name STRING,                                                                            |
|   year SMALLINT                                                                           |
| )                                                                                         |
| STORED AS TEXTFILE                                                                        |
| LOCATION 's3a://secure.datacoral/user/hive/warehouse/s3test.db/my_external_model__dbt_tmp'|
| TBLPROPERTIES ('numFiles'='1', 'totalSize'='93')                                          |
+-------------------------------------------------------------------------------------------+
Fetched 1 row(s) in 0.01s