### PR TITLE
Bump version to 1.0.5rc2

### DIFF
--- a/dbt/adapters/impala/__version__.py
+++ b/dbt/adapters/impala/__version__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version="1.0.4"
+version="1.0.5rc2"

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ with open('README.md') as f:
 
 package_name = "dbt-impala"
 # make sure this always matches dbt/adapters/dbt_impala/__version__.py
-package_version = "1.0.4"
+package_version = "1.0.5rc2"
 description = """The Impala adapter plugin for dbt"""
 
 setup(


### PR DESCRIPTION
Updating versions to 1.0.5rc2

Using https://github.com/sdairs/dbt-impala-demo to test against dbt-core==1.0.5rc2