### PR TITLE
Revert "Update setup.py for 1.0.4b release"

### DIFF
--- a/dbt/adapters/impala/__version__.py
+++ b/dbt/adapters/impala/__version__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version="1.0.4-1"
+version="1.0.4"

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ with open('README.md') as f:
 
 package_name = "dbt-impala"
 # make sure this always matches dbt/adapters/dbt_impala/__version__.py
-package_version = "1.0.4-1"
+package_version = "1.0.4"
 description = """The Impala adapter plugin for dbt"""
 
 setup(
@@ -40,12 +40,13 @@ setup(
         "impyla"
     ],
     classifiers=[
-        "Development Status :: 4 - Beta",
+        "Development Status :: 3 - Alpha",
         "Operating System :: MacOS :: MacOS X",
         "Operating System :: Microsoft :: Windows",
         "Operating System :: POSIX :: Linux",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "License :: OSI Approved :: Apache Software License"
     ],
     zip_safe=False


### PR DESCRIPTION
Reverts cloudera/dbt-impala#22

pip renames 1.0.4-1 to 1.0.4.post1 which breaks dbt --version 

Also, using .post releases is discouraged for changes that materially affect the code