### PR TITLE
Issue Summary: For incremental models, when using insert_overwrite mode along with partition clause, doesn't work as expected

### DIFF
--- a/dbt/include/impala/macros/incremental.sql
+++ b/dbt/include/impala/macros/incremental.sql
@@ -114,8 +114,10 @@
       {% set dest_columns = adapter.get_columns_in_relation(existing_relation) %}
     {% endif %}
 
-    {#-- since unique key is not supported, the follow macro (default impl), will only return insert stm, and hence is directly used here --#}
-    {% set build_sql = get_delete_insert_merge_sql(target_relation, tmp_relation, unique_key, dest_columns) %}
+    {#-- since unique key is not supported, the following macro (default impl), will only return insert stm, and hence is directly used here --#}
+    {#-- set build_sql = get_delete_insert_merge_sql(target_relation, tmp_relation, unique_key, dest_columns) --#}
+
+    {% set build_sql = get_insert_overwrite_sql(target_relation, tmp_relation, dest_columns) %}
   
   {% endif %}
 

--- a/dbt/include/impala/macros/insertoverwrite.sql
+++ b/dbt/include/impala/macros/insertoverwrite.sql
@@ -1,0 +1,39 @@
+{% macro get_quoted_csv_exclude(column_names, exclude_name) %}
+
+    {% set quoted = [] %}
+    {% for col in column_names -%}
+        {% if exclude_name|string() != col|string() %}
+           {%- do quoted.append(adapter.quote(col)) -%}
+        {% endif %}
+    {%- endfor %}
+
+    {%- set dest_cols_csv = quoted | join(', ') -%}
+    {{ return(dest_cols_csv) }}
+
+{% endmacro %}
+
+{% macro get_insert_overwrite_sql(target, source, dest_columns) -%}
+
+    {%- set partition_cols = config.get('partition_by', validator=validation.any[list]) -%}
+
+    {% if partition_cols is not none %}
+        {%- set partition_col = partition_cols[0] -%}
+
+        {%- set dest_cols_csv = get_quoted_csv_exclude(dest_columns | map(attribute="name"), "") -%}
+        {%- set dest_cols_csv_exclude = get_quoted_csv_exclude(dest_columns | map(attribute="name"), partition_col) -%}
+
+        insert overwrite {{ target }} ({{ dest_cols_csv_exclude }}) partition({{ partition_col }})
+            select {{ dest_cols_csv }}
+            from {{ source }}
+    {% else %}
+        {%- set dest_cols_csv = get_quoted_csv_exclude(dest_columns | map(attribute="name"), "") -%}
+
+        insert into {{ target }} ({{ dest_cols_csv }})
+        (
+            select {{ dest_cols_csv }}
+            from {{ source }}
+        )
+    {% endif %}
+
+{%- endmacro %}
+


### PR DESCRIPTION
Issue Summary: For incremental models, when using insert_overwrite mode along with partition clause, doesn't work as expected.

1. The code did not handle the partition clause correctly with insert statement that was being generated.
2. The code needed to use insert overwrite statement along with partition clause for the correct behaviour.

Test Plan:
1. Create a dbt model similar to (inc_over_model.sql):
   {{
    config(
        materialized='incremental',
        on_schema_change='ignore',
        partition_by=['some_date'],
        file_format='parquet',
        incremental_strategy='insert_overwrite',
    )
   }}

   select id,name,float_value,bool_value,updated_at,some_date from {{ ref('datetime_test') }}

   {% if is_incremental() %}
      where updated_at > (select max(updated_at) from {{ this }})
   {% endif %}
2. Run this model using:
   dbt run --select inc_over_model
3. The first run should create a new incremental model
4. Change source data (datetime_test)
5. Rerun, 2. This time the updated data should appear in the incremental model, based on the partition_by clause.