### PR TITLE
* bump version number to 1.1.0 to align with dbt-core versioning

### DIFF
--- a/dbt/adapters/impala/__version__.py
+++ b/dbt/adapters/impala/__version__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version="1.0.7"
+version="1.1.0"

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ with open('README.md') as f:
 
 package_name = "dbt-impala"
 # make sure this always matches dbt/adapters/dbt_impala/__version__.py
-package_version = "1.0.7"
+package_version = "1.1.0"
 description = """The Impala adapter plugin for dbt"""
 
 setup(


### PR DESCRIPTION
This PR for aligning version number of adapter with that of the targeted dbt-core (1.1.0) release.