### PR TITLE
update impyla dependency to 0.18a5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "dbt-core>=1.1.0",
-        "impyla"
+        "impyla>=0.18a5"
     ],
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
This dependency is added as this has the upstream fix https://github.com/cloudera/impyla/issues/487 and is more stable in Cloudera CML environment. 