### PR TITLE
Fix an issue that caused swappable test (view<->table) fail.

### DIFF
--- a/dbt/include/impala/macros/adapters.sql
+++ b/dbt/include/impala/macros/adapters.sql
@@ -249,8 +249,11 @@
 {% macro impala__rename_relation(from_relation, to_relation) -%}
   {% set from_rel_type = get_relation_type(from_relation) %}
   
-  {% call statement('drop_relation') %}
-    drop {{ from_rel_type }} if exists {{ to_relation }}
+  {% call statement('drop_relation_if_exists_table') %}
+    drop table if exists {{ to_relation }}
+  {% endcall %}
+  {% call statement('drop_relation_if_exists_view') %}
+    drop view if exists {{ to_relation }};
   {% endcall %}
   {% call statement('rename_relation') -%}
     {% if not from_rel_type %}


### PR DESCRIPTION
Synopsis:
The swappable functional test checks what happens when user changes materialization from view to table (or the other way round).
Resolution:
Instead of querying warehouse for object type, drop view and table objects in the rename_relation macro before performing a rename.
Testplan:
python3 -m pytest tests/functional -k 'TestSimpleMaterializationsImpala'
(swappable test of view-table should succeed, swappable test for incremental materialization will still fail)