### PR TITLE
Fix for swappable materialization test

### DIFF
--- a/dbt/include/impala/macros/adapters.sql
+++ b/dbt/include/impala/macros/adapters.sql
@@ -200,10 +200,12 @@
 {% endmacro %}
 
 {% macro impala__drop_relation(relation) -%}
-  {% set rel_type = get_relation_type(relation) %}
-  {% call statement('drop_relation', auto_begin=False) -%}
-    drop {{ rel_type }} if exists {{ relation }}
-  {%- endcall %}
+  {% call statement('drop_relation_if_exists_table') %}
+    drop table if exists {{ relation }}
+  {% endcall %}
+  {% call statement('drop_relation_if_exists_view') %}
+    drop view if exists {{ relation }}
+  {% endcall %}
 {% endmacro %}
 
 {% macro is_relation_present(relation) -%}

--- a/dbt/include/impala/macros/incremental.sql
+++ b/dbt/include/impala/macros/incremental.sql
@@ -91,6 +91,8 @@
   {% set trigger_full_refresh = (full_refresh_mode or existing_relation.is_view) %}
 
   {% if existing_relation is none %}
+      {# -- ensure that the target_relation is dropped before trying to create it #}
+      {{ drop_relation_if_exists(target_relation) }}
       {% set build_sql = create_table_as(False, target_relation, sql) %}
   {% elif trigger_full_refresh %}
       {#-- Make sure the backup doesn't exist so we don't encounter issues with the rename below #}
@@ -98,6 +100,9 @@
       {% set backup_identifier = model['name'] + '__' + time_stamp  + '__dbt_backup' %}
       {% set intermediate_relation = existing_relation.incorporate(path={"identifier": tmp_identifier}) %}
       {% set backup_relation = existing_relation.incorporate(path={"identifier": backup_identifier}) %}
+
+      {# -- ensure that the intermediate_relation is dropped before trying to create it #}
+      {{ drop_relation_if_exists(intermediate_relation) }}
 
       {% set build_sql = create_table_as(False, intermediate_relation, sql) %}
       {% set need_swap = true %}


### PR DESCRIPTION
Internal Ticket: https://jira.cloudera.com/projects/DBT/issues/DBT-226

Synopsis:
The swappable functional test checks what happens when user changes materialization from view to table for incremental models (or the other way round).

Resolution:
Instead of querying warehouse for object type, drop view and table objects in the drop_relation macro. Modify incremental flow to call this macro for every object (target or intermediate) that is created.

Testplan:
python3 -m pytest tests/functional -k 'TestSimpleMaterializationsImpala'
(This functional test should fully succeed)