### PR TITLE
Add macro generate_database_name always returning None

### DIFF
--- a/dbt/include/impala/macros/adapters.sql
+++ b/dbt/include/impala/macros/adapters.sql
@@ -331,6 +331,10 @@
     insert into {{target_relation}} ({{insert_cols_csv}}) select {{insert_cols_csv}} from {{staging_table}}
 {% endmacro %}
 
+{% macro impala__generate_database_name(custom_database_name=none, node=none) -%}
+  {% do return(None) %}
+{%- endmacro %}
+
 /* snapshots flow for impala */
 {% materialization snapshot, adapter='impala' %}
   {%- set config = model['config'] -%}


### PR DESCRIPTION
Add a macro to ensure that the database is always None, so that double qualified names are not generated.

This is required as in Impala there is no separate database name, so object names are qualified merely as schema.object_name and not database.schema.object_name
This macro merely ensures that the database is always None, ensuring that the fully qualified name generated by dbt is schema.object_name irrespective of ImpalaIncludePolicy