### PR TITLE
instrument query execution

### DIFF
--- a/dbt/adapters/impala/connections.py
+++ b/dbt/adapters/impala/connections.py
@@ -179,7 +179,6 @@ class ImpalaConnectionManager(SQLConnectionManager):
         payload = {
             "event_type": "dbt_impala_open",
             "auth": auth_type,
-            "connection_name": connection.name,
             "connection_state": connection.state,
             "elapsed_time": "{:.2f}".format(connection_end_time - connection_start_time),
         }
@@ -202,9 +201,7 @@ class ImpalaConnectionManager(SQLConnectionManager):
             credentials = connection.credentials
 
             payload = {
-                "id": "dbt_impala_close",
-                "unique_hash": hashlib.md5((str(credentials.host) + str(credentials.username)).encode()).hexdigest(),
-                "connection_name": connection.name,
+                "event_type": "dbt_impala_close",
                 "connection_state": ConnectionState.CLOSED,
                 "elapsed_time": "{:.2f}".format(connection_close_end_time - connection_close_start_time),
             }
@@ -266,7 +263,6 @@ class ImpalaConnectionManager(SQLConnectionManager):
             payload = {
                 "event_type": "dbt_impala_start_query",
                 "sql": log_sql,
-                "connection_name": connection.name,
                 "profile_name": self.profile.profile_name
             }
 
@@ -295,7 +291,6 @@ class ImpalaConnectionManager(SQLConnectionManager):
                 "sql": log_sql,
                 "elapsed_time": "{:.2f}".format(elapsed_time),
                 "status": query_status,
-                "connection_name": connection.name,
                 "profile_name": self.profile.profile_name
             }
 

--- a/dbt/adapters/impala/connections.py
+++ b/dbt/adapters/impala/connections.py
@@ -252,8 +252,9 @@ class ImpalaConnectionManager(SQLConnectionManager):
         if self.query_header:
             try:
                 additional_info = json.loads(self.query_header.comment.query_comment.strip())
-            except Exception:  # silently ignore error for parsing
+            except Exception as ex:  # silently ignore error for parsing
                 additional_info = {}
+                logger.debug(f"Unable to get query header {ex}")
 
         with self.exception_handler(sql):
             if abridge_sql_log:


### PR DESCRIPTION
A sample query execution record would look like:

[0m10:44:37.345522 [debug] [Thread-78 ]: Tracker adapter: Sending Event [{"data": {"id": "dbt_impala_start_query", "unique_hash": "0d957f2dd9707f9eea2aa91a24858cb4", "sql": "/* {\"app\": \"dbt\", \"dbt_version\": \"1.2.1\", \"profile_name\": \"dbtdemo\", \"target_name\": \"dev_impala_local\", \"node_id\": \"model.dbtdemo.my_second_dbt_model\"} */\n\n    show tables in dbtdemo like \"my_second_dbt_model__dbt_tmp\"\n  "}}]
^[[0m10:44:37.345685 [debug] [Thread-19 ]: On model.dbtdemo.my_second_dbt_model: /* {"app": "dbt", "dbt_version": "1.2.1", "profile_name": "dbtdemo", "target_name": "dev_impala_local", "node_id": "model.dbtdemo.my_second_dbt_model"} */

    show tables in dbtdemo like "my_second_dbt_model__dbt_tmp"
 
^[[0m10:44:37.357413 [debug] [Thread-19 ]: Tracker adapter: Usage tracking flag True
^[[0m10:44:37.358081 [debug] [Thread-79 ]: Tracker adapter: Sending Event [{"data": {"id": "dbt_impala_end_query", "unique_hash": "0d957f2dd9707f9eea2aa91a24858cb4", "sql": "/* {\"app\": \"dbt\", \"dbt_version\": \"1.2.1\", \"profile_name\": \"dbtdemo\", \"target_name\": \"dev_impala_local\", \"node_id\": \"model.dbtdemo.my_second_dbt_model\"} */\n\n    show tables in dbtdemo like \"my_second_dbt_model__dbt_tmp\"\n  ", "elapsed_time": "0.01", "status": "OK"}}]
^[[0m10:44:37.358250 [debug] [Thread-19 ]: SQL status: OK in 0.01 seconds

