### PR TITLE
capture errors in query execution

### DIFF
--- a/dbt/adapters/impala/cloudera_tracking.py
+++ b/dbt/adapters/impala/cloudera_tracking.py
@@ -109,7 +109,7 @@ def track_usage(tracking_payload):
 
     global usage_tracking
 
-    logger.debug(f"Usage tracking flag {usage_tracking}")
+    logger.debug(f"Usage tracking flag {usage_tracking}. To turn on/off use usage_tracking flag in profiles.yml")
 
     # if usage_tracking is disabled, quit
     if not usage_tracking:


### PR DESCRIPTION
Testplan
a) create a sample dbt project
b) edit any model file to introduce error in the sql statement
c) execute dbt run. dbt should fail normally, for instance: 
ganesh.venkateshwara@MacBook-Pro dbtdemo % dbt run 11:07:39  Running with dbt=1.1.2
11:07:40  Found 3 models, 4 tests, 0 snapshots, 0 analyses, 191 macros, 0 operations, 1 seed file, 0 sources, 0 exposures, 0 metrics 11:07:40
11:07:40  Concurrency: 4 threads (target='dev_impala_local') 11:07:40
11:07:40  1 of 3 START table model dbtdemo.my_first_dbt_model ............................ [RUN] 11:10:02  1 of 3 OK created table model dbtdemo.my_first_dbt_model ....................... [OK in 141.63s] 11:10:02  2 of 3 START incremental model dbtdemo.my_incremental_model .................... [RUN] 11:10:02  3 of 3 START view model dbtdemo.my_second_dbt_model ............................ [RUN] 11:10:07  3 of 3 ERROR creating view model dbtdemo.my_second_dbt_model ................... [ERROR in 5.61s] 11:11:44  2 of 3 OK created incremental model dbtdemo.my_incremental_model ............... [OK in 102.60s] 11:11:44
11:11:44  Finished running 1 table model, 1 view model, 1 incremental model in 244.60s. 11:11:44
11:11:44  Completed with 1 error and 0 warnings:
11:11:44
11:11:44  Runtime Error in model my_second_dbt_model (models/example/my_second_dbt_model.sql)
11:11:44    AnalysisException: WHERE clause requires return type 'BOOLEAN'. Actual type is 'TINYINT'.
11:11:44
11:11:44
11:11:44  Done. PASS=2 WARN=0 ERROR=1 SKIP=0 TOTAL=3

In addition, the following log will be generated in logs/dbt.log:
11:10:07.633478 [debug] [Thread-72 ]: Tracker adapter: Sending Event [{"data": {"event_type": "dbt_impala_end_query", "sql": "/* {\"app\": \"dbt\", \"dbt_version\": \"1.1.2\", \"profile_name\": \"dbtdemo\", \"target_name\": \"dev_impala_local\", \"node_id\": \"model.dbtdemo.my_second_dbt_model\"} */\n\n\n  create view\n    dbtdemo.my_second_dbt_model__dbt_tmp\n    \n  as\n    /* Use the `ref` function to select from other models */ \n\n\n\nselect *\nfrom dbtdemo.my_first_dbt_model\nwhere id\n  ;", "elapsed_time": "5.52", "status": "AnalysisException: WHERE clause requires return type 'BOOLEAN'. Actual type is 'TINYINT'.\n", "profile_name": "dbtdemo", "python_version": "3.9.11", "system": "Darwin", "machine": "x86_64", "platform": "macOS-12.6-x86_64-i386-64bit", "dbt_version": "1.1.2", "dbt_adapter": "impala-1.1.2", "id": "c28d0d05-96eb-4fff-ba78-0da393df8173", "unique_host_hash": "421aa90e079fa326b6494f812ad13e79", "unique_user_hash": "6adf97f83acf6453d4a6a4b1070f3754", "unique_session_hash": "be16db3aa40d0f20ca2ecabd4e499e82", "project_name": "dbtdemo", "target_name": "dev_impala_local", "no_of_threads": 4}}]