### PR TITLE
instrument model usage.

### DIFF
--- a/dbt/adapters/impala/cloudera_tracking.py
+++ b/dbt/adapters/impala/cloudera_tracking.py
@@ -113,6 +113,7 @@ def track_usage(tracking_payload):
 
     # if usage_tracking is disabled, quit
     if not usage_tracking:
+        logger.debug(f"Skipping Event {tracking_payload}")
         return
 
     # inject other static payload to tracking_payload

--- a/dbt/include/impala/macros/incremental.sql
+++ b/dbt/include/impala/macros/incremental.sql
@@ -62,6 +62,8 @@
   {% set tmp_relation = make_temp_relation(target_relation, '__' + time_stamp + '__dbt_tmp') %}
   {%- set full_refresh_mode = (should_full_refresh()) -%}
 
+  {% do target_relation.log_relation(raw_strategy) %}
+
   {% set tmp_identifier = model['name'] + '__' + time_stamp + '__dbt_tmp' %}
   {% set backup_identifier = model['name'] + '__' + time_stamp + "__dbt_backup" %}
 


### PR DESCRIPTION
instrument model usage.

track two events:
1) model is accessed
7:52:35.778463 [debug] [Thread-133]: Tracker adapter: Sending Event [{"data": {"event_type": "dbt_impala_model_access", "model_name": "dbtdemo.my_second_dbt_model", "model_type": "view", "python_version": "3.9.12", "system": "Darwin", "machine": "arm64", "platform": "macOS-12.6-arm64-arm-64bit", "dbt_version": "1.1.2", "dbt_adapter": "impala-1.1.2", "id": "17b4de51-0125-4323-a195-2d41d0f702a7", "unique_host_hash": "a80df3703d95f6c576ac4c680a231390", "unique_user_hash": "6444baa7f3e0fa703845a1ca38c973b6", "unique_session_hash": "2415b7a36210b424b8c164d8707ff6ff", "project_name": "dbtdemo", "target_name": "dev_impala_ldap", "no_of_threads": 1}}]

2) incremental model is created
07:49:55.442522 [debug] [Thread-79 ]: Tracker adapter: Sending Event [{"data": {"event_type": "dbt_impala_new_incremental", "model_name": "dbtdemo.my_incremental_model", "model_type": "table", "incremental_strategy": "append", "python_version": "3.9.12", "system": "Darwin", "machine": "arm64", "platform": "macOS-12.6-arm64-arm-64bit", "dbt_version": "1.1.2", "dbt_adapter": "impala-1.1.2", "id": "17b4de51-0125-4323-a195-2d41d0f702a7", "unique_host_hash": "a80df3703d95f6c576ac4c680a231390", "unique_user_hash": "6444baa7f3e0fa703845a1ca38c973b6", "unique_session_hash": "2415b7a36210b424b8c164d8707ff6ff", "project_name": "dbtdemo", "target_name": "dev_impala_ldap", "no_of_threads": 1}}]