### PR TITLE
Add http error identification for credentials and hostname errors

### DIFF
--- a/dbt/adapters/impala/connections.py
+++ b/dbt/adapters/impala/connections.py
@@ -119,9 +119,9 @@ class ImpalaConnectionManager(SQLConnectionManager):
         except HttpError as httpError:
             LOGGER.debug("Authorization error: {}".format(httpError))
             raise dbt.exceptions.RuntimeException ("HTTP Authorization error: " + str(httpError) + ", please check your credentials")
-        except HiveServer2Error as hiveError:
-            LOGGER.debug("Server connection error: {}".format(hiveError))
-            raise dbt.exceptions.RuntimeException ("Unable to establish connection to Hive server: " + str(hiveError))
+        except HiveServer2Error as servError:
+            LOGGER.debug("Server connection error: {}".format(servError))
+            raise dbt.exceptions.RuntimeException ("Unable to establish connection to Impala server: " + str(servError))
         except DatabaseError as dbError:
             LOGGER.debug("Database connection error: {}".format(str(dbError)))
             raise dbt.exceptions.DatabaseException("Database Connection error: " + str(dbError))

--- a/dbt/adapters/impala/connections.py
+++ b/dbt/adapters/impala/connections.py
@@ -32,6 +32,9 @@ from dbt.events.types import ConnectionUsed, SQLQuery, SQLQueryStatus
 from dbt.logger import GLOBAL_LOGGER as LOGGER
 
 import impala.dbapi
+from impala.error import DatabaseError
+from impala.error import HttpError
+from impala.error import HiveServer2Error
 
 import dbt.adapters.impala.__version__ as ver
 import dbt.adapters.impala.cloudera_tracking as tracker
@@ -113,9 +116,15 @@ class ImpalaConnectionManager(SQLConnectionManager):
     def exception_handler(self, sql: str):
         try:
             yield
-        except impala.dbapi.DatabaseError as exc:
-            LOGGER.debug("dbt-impala error: {}".format(str(exc)))
-            raise dbt.exceptions.DatabaseException(str(exc))
+        except HttpError as httpError:
+            LOGGER.debug("Authorization error: {}".format(httpError))
+            raise dbt.exceptions.RuntimeException ("HTTP Authorization error: " + str(httpError) + ", please check your credentials")
+        except HiveServer2Error as hiveError:
+            LOGGER.debug("Server connection error: {}".format(hiveError))
+            raise dbt.exceptions.RuntimeException ("Unable to establish connection to Hive server: " + str(hiveError))
+        except DatabaseError as dbError:
+            LOGGER.debug("Database connection error: {}".format(str(dbError)))
+            raise dbt.exceptions.DatabaseException("Database Connection error: " + str(dbError))
         except Exception as exc:
             LOGGER.debug("Error running SQL: {}".format(sql))
             raise dbt.exceptions.RuntimeException(str(exc))


### PR DESCRIPTION
Internal ticket: https://jira.cloudera.com/browse/DBT-398

The error printed seems to be generic, so adding
code to identity the failure from Impala connection.

Test plan:
  * Move into a dbt impala project and install dbt-impala from this git repo
  * Add profile details in your home dbt file like below, 
    dbt_impala_demo:
    outputs:
      dev:
        auth_type: ldap
        host: {}
        http_path: {}
        password: {}
        port: 443
        schema: dbt_impala_demo
        dbname: dbt_impala_demo
        threads: 4
        type: impala
        use_http_transport: true
        use_ssl: true
        user: {}
    target: dev
  * Update with wrong hostname or wrong user credentials
  * run > dbt debug, and you should see the type of error in the console
  * Add below snowplow configs to your .env if you face any snowplow error   
  SNOWPLOW_ENDPOINT=https://dcevents.cldrteam.datacoral.io/cldrteam/apievents
  SNOWPLOW_TIMEOUT=10
  SNOWPLOW_API_KEY=<your_key>
  SNOWPLOW_ENNV=prod

Signed-off-by: Sanjeev kumar N <sanjeevitcit@gmail.com>