### PR TITLE
skip fetching warehouse permission when no username is available

### DIFF
--- a/dbt/adapters/impala/impl.py
+++ b/dbt/adapters/impala/impl.py
@@ -412,26 +412,36 @@ class ImpalaAdapter(SQLAdapter):
     def debug_query(self) -> None:
         self.execute("select 1 as id")
         username = ""
+
+        # query user permissions where available
         try:
             username = self.config.credentials.username
-            sql_query = "show grant user `" + username + "` on server"
-            _, table = self.execute(sql_query, True, True)
-            permissions_object = []
-            json_funcs = [c.jsonify for c in table.column_types]
+            if not username: # username is not available when auth_type is insecure or kerberos
+                logger.debug("No username available to fetch permissions")
+                payload = {
+                    "event_type": "dbt_impala_debug_and_fetch_permissions",
+                    "permissions": "NA",
+                }
+                tracker.track_usage(payload)
+            else:
+                sql_query = "show grant user `" + username + "` on server"
+                _, table = self.execute(sql_query, True, True)
+                permissions_object = []
+                json_funcs = [c.jsonify for c in table.column_types]
 
-            for row in table.rows:
-                values = tuple(json_funcs[i](d) for i, d in enumerate(row))
-                permissions_object.append(OrderedDict(zip(row.keys(), values)))
+                for row in table.rows:
+                    values = tuple(json_funcs[i](d) for i, d in enumerate(row))
+                    permissions_object.append(OrderedDict(zip(row.keys(), values)))
 
-            permissions_json = json.dumps(permissions_object)
+                permissions_json = json.dumps(permissions_object)
 
-            payload = {
-                "event_type": "dbt_impala_debug_and_fetch_permissions",
-                "permissions": permissions_json,
-            }
-            tracker.track_usage(payload)
+                payload = {
+                    "event_type": "dbt_impala_debug_and_fetch_permissions",
+                    "permissions": permissions_json,
+                }
+                tracker.track_usage(payload)
         except Exception as ex:
-            logger.debug(
+            logger.error(
                 f"Failed to fetch permissions for user: {username}. Exception: {ex}"
             )
             self.connections.get_thread_connection().handle.close()


### PR DESCRIPTION
## Describe your changes
when no user name is available for an auth_type, skip getting warehouse permissions

## Internal Jira ticket number or external issue link
Internal ticket: https://jira.cloudera.com/browse/DBT-439

## Testing procedure/screenshots(if appropriate):
For a dbt profile which doesn't need username, for instance auth_type = GSSAPI, run dbt debug. The logs should have an entry similar to the following:

11:49:09.565630 [debug] [MainThread]: Impala adapter: No username available to fetch permissions
11:49:09.566994 [debug] [MainThread]: Tracker adapter: Usage tracking flag True. To turn on/off use usage_tracking flag in profiles.yml
11:49:09.568384 [debug] [Thread-4  ]: Tracker adapter: Sending Event [{"data": {"event_type": "dbt_impala_debug_and_fetch_permissions", "permissions": "NA", "auth": "N/A", "connection_state": "N/A", "elapsed_time": "N/A", "incremental_strategy": "N/A", "model_name": "N/A", "model_type": "N/A", "profile_name": "N/A", "sql_type": "N/A", "id": "ce5be2bf-21e5-4b4d-b9c3-dd2ea884be7e", "unique_host_hash": "755624c34834153e99eb60a0d7fc07ac", "unique_user_hash": "6adf97f83acf6453d4a6a4b1070f3754", "unique_session_hash": "07bef15b9cba1010724f86bb7c9879f2", "python_version": "3.9.12", "system": "Darwin", "machine": "arm64", "platform": "macOS-12.6-arm64-arm-64bit", "dbt_version": "1.1.2", "dbt_adapter": "impala-1.1.4", "ml_runtime_edition": "", "ml_runtime_git_hash": "", "ml_runtime_kernel": "", "ml_runtime_editor": "", "ml_runtime_gbn": "", "ml_runtime_full_version": "", "ml_runtime_description": "", "ml_runtime_maintenance_version": "", "ml_runtime_metadata_version": "", "project_name": "p_strategy_impala", "target_name": "dev_impala_kerberos", "no_of_threads": 1}}]

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] I have formatted my added/modified code to follow pep-8 standards
- [X] I have checked suggestions from python linter to make sure code is of good quality.
