### PR TITLE
[DBT-555] upgrade dbt-core, functional tests for 1.2 migration

### DIFF
--- a/dbt/adapters/impala/__version__.py
+++ b/dbt/adapters/impala/__version__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version="1.1.4"
+version="1.2.0"

--- a/dbt/adapters/impala/cloudera_tracking.py
+++ b/dbt/adapters/impala/cloudera_tracking.py
@@ -89,7 +89,11 @@ def populate_unique_ids(cred: Credentials):
     timestamp = str(time.time()).encode()
 
     # dbt invocation id
-    unique_ids["id"] = active_user.invocation_id
+    if active_user:
+       unique_ids["id"] = active_user.invocation_id
+    else:
+       unique_ids["id"] = "N/A"
+
     # hashed host name
     unique_ids["unique_host_hash"] = hashlib.md5(host).hexdigest()
     # hashed username

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ def _get_dbt_core_version():
 
 package_name = "dbt-impala"
 # make sure this always matches dbt/adapters/dbt_impala/__version__.py
-package_version = "1.1.4"
+package_version = "1.2.0"
 description = """The Impala adapter plugin for dbt"""
 
 dbt_core_version = _get_dbt_core_version()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,12 +7,11 @@ pytest_plugins = ["dbt.tests.fixtures.project"]
 
 impala_ldap = {
         'type': 'impala',
-        'threads': 5,
-        'dbname': 'dbttest',
-        'schema': 'dbttest',
-        'host': 'coordinator-dbt-impala.dw-ciadev.cna2-sx9y.cloudera.site',
-        'http_path': 'cliservice',
-        'port': 443,
+        'threads': 4,
+        'schema': 'dbt_adapter_test',
+        'host':  os.getenv('IMPALA_HOST'),
+        'http_path': os.getenv('IMPALA_HTTP_PATH'),
+        'port': int(os.getenv('IMPALA_PORT')),
         'auth_type': 'ldap',
         'use_http_transport': True,
         'use_ssl': True,


### PR DESCRIPTION
## Describe your changes
* update version to 1.2.0 to being migration to dbt-core==1.2.x
* fix an issue with tracking library that caused functional test to fail
* currently 3 tests are failing, which needs to be separately addressed: tests/functional/adapter/test_basic.py::TestSnapshotCheckColsImpala::test_snapshot_check_cols FAILED tests/functional/adapter/test_basic.py::TestSnapshotTimestampImpala::test_snapshot_timestamp FAILED tests/functional/adapter/test_basic.py::TestBaseAdapterMethod::test_adapter_methods FAILED 

## Internal Jira ticket number or external issue link
DBT-555

## Testing procedure/screenshots(if appropriate):
run functional test with upgraded dbt-core==1.2.1 using:
python -m pytest tests/functional/adapter/test_basic.py

All tests except the following should pass:
tests/functional/adapter/test_basic.py::TestSnapshotCheckColsImpala::test_snapshot_check_cols FAILED tests/functional/adapter/test_basic.py::TestSnapshotTimestampImpala::test_snapshot_timestamp FAILED tests/functional/adapter/test_basic.py::TestBaseAdapterMethod::test_adapter_methods FAILED 

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] I have formatted my added/modified code to follow pep-8 standards
- [X] I have checked suggestions from python linter to make sure code is of good quality.
