### PR TITLE
fix issues with cloudera_tracking

### DIFF
--- a/dbt/adapters/impala/cloudera_tracking.py
+++ b/dbt/adapters/impala/cloudera_tracking.py
@@ -89,7 +89,11 @@ def populate_unique_ids(cred: Credentials):
     timestamp = str(time.time()).encode()
 
     # dbt invocation id
-    unique_ids["id"] = active_user.invocation_id
+    if active_user:
+       unique_ids["id"] = active_user.invocation_id
+    else:
+       unique_ids["id"] = "N/A"
+
     # hashed host name
     unique_ids["unique_host_hash"] = hashlib.md5(host).hexdigest()
     # hashed username

--- a/dbt/adapters/impala/cloudera_tracking.py
+++ b/dbt/adapters/impala/cloudera_tracking.py
@@ -198,7 +198,7 @@ def track_usage(tracking_payload):
     tracking_payload = _merge_keys(profile_info, tracking_payload)
 
     # form the tracking data
-    tracking_data = {"data": tracking_payload}
+    tracking_data = {"data": json.dumps(tracking_payload)}
 
     # inner function which actually calls the endpoint
     def _tracking_func(data):


### PR DESCRIPTION
## Describe your changes

* In some environemnts such as pytest for running functional tests, active_user is not available and causes a runtime exception. This PR simiply checks if a valid active_user object is available before attempting to use it.
* Addresses a data format issue with the data being sent for instrumentation.