### PR TITLE
recycle cursor object for a connection

### DIFF
--- a/dbt/adapters/impala/cloudera_tracking.py
+++ b/dbt/adapters/impala/cloudera_tracking.py
@@ -227,7 +227,6 @@ def track_usage(tracking_payload):
         res = None
 
         try:
-            logger.debug(f"Sending Event {data}")
             res = requests.post(
                 SNOWPLOW_ENDPOINT, data=data, headers=headers, timeout=SNOWPLOW_TIMEOUT
             )
@@ -237,6 +236,8 @@ def track_usage(tracking_payload):
             usage_tracking = False
 
         return res
+
+    logger.debug(f"Sending Event {tracking_data}")
 
     # call the tracking function in a Thread
     the_track_thread = threading.Thread(


### PR DESCRIPTION
## Describe your changes
Recycle cursor object for a connection.
Earlier implementation opened a new cursor object for every sql that is executed. This is fine for most part, but when using pre-hooks with SET commands in Impala, the cursor context is lost resulting in the SET parameters not being available or enforced for subsequent queries being executed. 

## Testing procedure/screenshots(if appropriate):
One instance where the SET command is needed is for setting the request pool. To test this create a request pool for impala (say root.small), and then create a model with pre-hook as follows:
<pre>
{{
   config(
     pre_hook=["set request_pool='root.small'"],
     materialized='table'
   )
}}

with source_data as (
    select 1 as id
    union all
    select null as id
)
select *
from source_data;
</pre>

Next run the model as follows:
dbt run --select models/example/my_first_dbt_model.sql

Check from impala Query logs if the request pool is being set for the SQL, see for instance:
![image](https://user-images.githubusercontent.com/4781546/198570467-3deb5d13-1380-46ca-a967-a139249437a1.png)
 
## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] I have formatted my added/modified code to follow pep-8 standards
- [X] I have checked suggestions from python linter to make sure code is of good quality.
