### PR TITLE
add new test TestBaseIncrementalNotSchemaChange

### DIFF
--- a/tests/functional/adapter/test_basic.py
+++ b/tests/functional/adapter/test_basic.py
@@ -21,7 +21,7 @@ from dbt.tests.adapter.basic.test_singular_tests import BaseSingularTests
 from dbt.tests.adapter.basic.test_singular_tests_ephemeral import BaseSingularTestsEphemeral
 from dbt.tests.adapter.basic.test_empty import BaseEmpty
 from dbt.tests.adapter.basic.test_ephemeral import BaseEphemeral
-from dbt.tests.adapter.basic.test_incremental import BaseIncremental
+from dbt.tests.adapter.basic.test_incremental import BaseIncremental, BaseIncrementalNotSchemaChange
 from dbt.tests.adapter.basic.test_generic_tests import BaseGenericTests
 from dbt.tests.adapter.basic.test_snapshot_check_cols import BaseSnapshotCheckCols
 from dbt.tests.adapter.basic.test_snapshot_timestamp import BaseSnapshotTimestamp
@@ -117,4 +117,20 @@ class TestBaseAdapterMethod(BaseAdapterMethod):
 
 class TestBaseUtilsImpala(BaseUtils):
      pass
+
+incremental_not_schema_change_sql = """
+{{ config(materialized="incremental", incremental_strategy="append") }}
+select
+    concat(concat('1', '-'), cast(current_timestamp() as string)) as user_id_current_time,
+    {% if is_incremental() %}
+        'thisis18characters' as platform
+    {% else %}
+        'okthisis20characters' as platform
+    {% endif %}
+"""
+
+class TestBaseIncrementalNotSchemaChange(BaseIncrementalNotSchemaChange):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"incremental_not_schema_change.sql": incremental_not_schema_change_sql}
 


### PR DESCRIPTION
adds a new test TestBaseIncrementalNotSchemaChange for dbt-core==1.3

Test result:
<pre>
 python -m pytest tests/functional/adapter/test_basic.py -k 'TestBaseIncrementalNotSchemaChange'
 
============================= test session starts ==============================
platform darwin -- Python 3.9.12, pytest-7.1.3, pluggy-1.0.0
rootdir: /Users/ganesh.venkateshwara/code/cloudera/dbt-impala, configfile: pytest.ini
collected 12 items / 11 deselected / 1 selected

tests/functional/adapter/test_basic.py .                                 [100%]

=============================== warnings summary ===============================
../../venv/dev/dev-dbt-impala/lib/python3.9/site-packages/_pytest/config/__init__.py:1253
  /Users/ganesh.venkateshwara/code/venv/dev/dev-dbt-impala/lib/python3.9/site-packages/_pytest/config/__init__.py:1253: PytestConfigWarning: Unknown config option: env_files

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========== 1 passed, 11 deselected, 1 warning in 125.96s (0:02:05) ============
</pre>