### PR TITLE
add new test TestConcurrencyImpala

### DIFF
--- a/tests/functional/adapter/test_concurrency.py
+++ b/tests/functional/adapter/test_concurrency.py
@@ -1,0 +1,31 @@
+import pytest
+from pathlib import Path
+from dbt.tests.util import (
+     run_dbt,
+     check_relations_equal,
+     rm_file,
+     write_file
+     )
+from dbt.tests.adapter.concurrency.test_concurrency import (
+     BaseConcurrency,
+     seeds__update_csv
+     )
+
+class TestConcurrencyImpala(BaseConcurrency):
+     def test_concurrency_impala(self, project):
+         run_dbt(["seed", "--select", "seed"])
+         results = run_dbt(["run"], expect_pass=False)
+         assert len(results) == 7
+         check_relations_equal(project.adapter, ["SEED", "VIEW_MODEL"])
+         check_relations_equal(project.adapter, ["SEED", "DEP"])
+         check_relations_equal(project.adapter, ["SEED", "TABLE_A"])
+         check_relations_equal(project.adapter, ["SEED", "TABLE_B"])
+
+         rm_file(project.project_root, "seeds", "seed.csv")
+         write_file(seeds__update_csv, project.project_root + '/seeds', "seed.csv")
+         results = run_dbt(["run"], expect_pass=False)
+         assert len(results) == 7
+         check_relations_equal(project.adapter, ["SEED", "VIEW_MODEL"])
+         check_relations_equal(project.adapter, ["SEED", "DEP"])
+         check_relations_equal(project.adapter, ["SEED", "TABLE_A"])
+         check_relations_equal(project.adapter, ["SEED", "TABLE_B"])


### PR DESCRIPTION
Add new test TestConcurrencyImpala.

Test run:
<pre>
python -m pytest tests/functional/adapter/test_concurrency.py
============================= test session starts ==============================
platform darwin -- Python 3.9.12, pytest-7.1.3, pluggy-1.0.0
rootdir: /Users/ganesh.venkateshwara/code/cloudera/dbt-impala, configfile: pytest.ini
collected 1 item

tests/functional/adapter/test_concurrency.py .                           [100%]

=============================== warnings summary ===============================
../../venv/dev/dev-dbt-impala/lib/python3.9/site-packages/_pytest/config/__init__.py:1253
  /Users/ganesh.venkateshwara/code/venv/dev/dev-dbt-impala/lib/python3.9/site-packages/_pytest/config/__init__.py:1253: PytestConfigWarning: Unknown config option: env_files

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=================== 1 passed, 1 warning in 576.24s (0:09:36) ===================
</pre>
