### PR TITLE
add test BaseCurrentTimestampNaive

### DIFF
--- a/tests/functional/adapter/test_utils.py
+++ b/tests/functional/adapter/test_utils.py
@@ -34,6 +34,7 @@ from dbt.tests.adapter.utils.test_date_trunc import BaseDateTrunc
 from dbt.tests.adapter.utils.test_last_day import BaseLastDay
 from dbt.tests.adapter.utils.test_listagg import BaseListagg
 from dbt.tests.adapter.utils.test_intersect import BaseIntersect
+from dbt.tests.adapter.utils.test_current_timestamp import BaseCurrentTimestampNaive
 
 from dbt.tests.adapter.utils.fixture_concat import (
     seeds__data_concat_csv,
@@ -799,4 +800,7 @@ class TestListagg(BaseListagg):
         }
 
 class TestIntersect(BaseIntersect):
+    pass
+
+class TestCurrentTimestamp(BaseCurrentTimestampNaive):
     pass


### PR DESCRIPTION
## Testing procedure/screenshots(if appropriate):
<pre>
python -m pytest tests/functional/adapter/test_utils.py -k 'TestCurrentTimestamp'
collected 22 items / 20 deselected / 2 selected

tests/functional/adapter/test_utils.py ..                                [100%]

=============================== warnings summary ===============================
../../venv/dev/dev-dbt-impala/lib/python3.9/site-packages/_pytest/config/__init__.py:1253
  /Users/ganesh.venkateshwara/code/venv/dev/dev-dbt-impala/lib/python3.9/site-packages/_pytest/config/__init__.py:1253: PytestConfigWarning: Unknown config option: env_files

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============ 2 passed, 20 deselected, 1 warning in 82.08s (0:01:22) ============
</pre>