### PR TITLE
Mark utils functions that are not supported in Impala

### DIFF
--- a/dbt/include/impala/macros/utils/array_append.sql
+++ b/dbt/include/impala/macros/utils/array_append.sql
@@ -1,0 +1,3 @@
+{% macro impala__array_append(array, new_element) -%}
+  {{ exceptions.raise_compiler_error("Array functions are not supported in Impala") }}
+{%- endmacro %}

--- a/dbt/include/impala/macros/utils/array_concat.sql
+++ b/dbt/include/impala/macros/utils/array_concat.sql
@@ -1,0 +1,3 @@
+{% macro impala__array_concat(array_1, array_2) -%}
+  {{ exceptions.raise_compiler_error("Array functions are not supported in Impala") }}
+{%- endmacro %}

--- a/dbt/include/impala/macros/utils/array_construct.sql
+++ b/dbt/include/impala/macros/utils/array_construct.sql
@@ -1,0 +1,3 @@
+{% macro impala__array_construct(inputs, data_type) -%}
+  {{ exceptions.raise_compiler_error("Array functions are not supported in Impala") }}
+{%- endmacro %}

--- a/dbt/include/impala/macros/utils/datediff.sql
+++ b/dbt/include/impala/macros/utils/datediff.sql
@@ -121,7 +121,7 @@
 
     {%- else -%}
 
-        {{ exceptions.raise_compiler_error("macro datediff not implemented for datepart ~ '" ~ datepart ~ "' ~ on Spark") }}
+        {{ exceptions.raise_compiler_error("macro datediff not implemented for datepart ~ '" ~ datepart ~ "' ~ on Impala") }}
 
     {%- endif -%}
 


### PR DESCRIPTION
Array functions are not supported in Impala, and hence are marked to throw an Not implemented exception when called. 
Also fix typo in error message.