### PR TITLE
refactor cloudera_tracking: event type as enums, optional userkey, warehouse version fetch

### DIFF
--- a/dbt/adapters/impala/cloudera_tracking.py
+++ b/dbt/adapters/impala/cloudera_tracking.py
@@ -27,17 +27,15 @@ from dbt.adapters.base import Credentials
 from dbt.events import AdapterLogger
 from decouple import config
 
-from enum import Enum
-
-# enum for all event types
-class TrackingEventType(Enum):
-    debug_and_fetch_permission = 1,
-    open = 2,
-    close = 3,
-    start_query = 4,
-    end_query = 5,
-    new_incremental = 6,
-    model_access = 7
+# all event types
+class TrackingEventType:
+    DEBUG = "debug_and_fetch_permission"
+    OPEN = "open"
+    CLOSE = "close"
+    START_QUERY = "start_query"
+    END_QUERY = "end_query"
+    INCREMENTAL = "incremental"
+    MODEL_ACCESS = "model_access"
 
 # global logger
 logger = AdapterLogger("Tracker")
@@ -230,6 +228,8 @@ def track_usage(tracking_payload):
             "x-datacoral-passthrough": "true",
         }
 
+        logger.debug(f"Sending Event {data}")
+
         data = json.dumps([data])
 
         res = None
@@ -244,8 +244,6 @@ def track_usage(tracking_payload):
             usage_tracking = False
 
         return res
-
-    logger.debug(f"Sending Event {tracking_data}")
 
     # call the tracking function in a Thread
     the_track_thread = threading.Thread(

--- a/dbt/adapters/impala/cloudera_tracking.py
+++ b/dbt/adapters/impala/cloudera_tracking.py
@@ -74,9 +74,9 @@ def populate_dbt_deployment_env_info():
     default_value = "{}"  # if environment variables doesn't exist add empty json as default
     dbt_deployment_env_info["dbt_deployment_env"] = json.loads(os.environ.get('DBT_DEPLOYMENT_ENV', default_value))
 
-def populate_unique_ids(cred: Credentials):
+def populate_unique_ids(cred: Credentials, userkey="username"):
     host = str(cred.host).encode()
-    user = str(cred.username).encode()
+    user = str(getattr(cred, userkey)).encode()
     timestamp = str(time.time()).encode()
 
     # dbt invocation id

--- a/dbt/adapters/impala/connections.py
+++ b/dbt/adapters/impala/connections.py
@@ -15,7 +15,6 @@
 from contextlib import contextmanager
 from dataclasses import dataclass
 
-import os
 import time
 import dbt.exceptions
 
@@ -246,7 +245,7 @@ class ImpalaConnectionManager(SQLConnectionManager):
 
         # track usage
         payload = {
-            "event_type": tracker.TrackingEventType.open.name,
+            "event_type": tracker.TrackingEventType.OPEN,
             "auth": auth_type,
             "connection_state": connection.state,
             "elapsed_time": "{:.2f}".format(
@@ -273,7 +272,7 @@ class ImpalaConnectionManager(SQLConnectionManager):
             connection_close_end_time = time.time()
 
             payload = {
-                "event_type": tracker.TrackingEventType.close.name,
+                "event_type": tracker.TrackingEventType.CLOSE,
                 "connection_state": ConnectionState.CLOSED,
                 "elapsed_time": "{:.2f}".format(
                     connection_close_end_time - connection_close_start_time
@@ -309,8 +308,7 @@ class ImpalaConnectionManager(SQLConnectionManager):
 
             tracker.populate_warehouse_info({ "version": ImpalaConnectionManager.impala_version, "build": "NA" })
 
-        os.environ['DBT_IMPALA_VERSION'] = ImpalaConnectionManager.impala_version 
-        logger.debug(f"IMPALA VERSION {os.getenv('DBT_IMPALA_VERSION')}")
+        logger.debug(f"IMPALA VERSION {'ImpalaConnectionManager.impala_version'}")
 
     @classmethod
     def get_response(cls, cursor):
@@ -360,7 +358,7 @@ class ImpalaConnectionManager(SQLConnectionManager):
 
             # track usage
             payload = {
-                "event_type": tracker.TrackingEventType.start_query.name,
+                "event_type": tracker.TrackingEventType.START_QUERY,
                 "sql": log_sql,
                 "profile_name": self.profile.profile_name
             }
@@ -390,7 +388,7 @@ class ImpalaConnectionManager(SQLConnectionManager):
             elapsed_time = time.time() - pre
 
             payload = {
-                "event_type": tracker.TrackingEventType.end_query.name,
+                "event_type": tracker.TrackingEventType.END_QUERY,
                 "sql": log_sql,
                 "elapsed_time": "{:.2f}".format(elapsed_time),
                 "status": query_status,

--- a/dbt/adapters/impala/connections.py
+++ b/dbt/adapters/impala/connections.py
@@ -15,6 +15,7 @@
 from contextlib import contextmanager
 from dataclasses import dataclass
 
+import os
 import time
 import dbt.exceptions
 
@@ -153,6 +154,8 @@ class ImpalaConnectionWrapper(object):
 class ImpalaConnectionManager(SQLConnectionManager):
     TYPE = "impala"
 
+    impala_version = None
+
     def __init__(self, profile: AdapterRequiredConfig):
         super().__init__(profile)
         # generate profile related object for instrumentation.
@@ -232,6 +235,8 @@ class ImpalaConnectionManager(SQLConnectionManager):
 
             connection.state = ConnectionState.OPEN
             connection.handle = ImpalaConnectionWrapper(handle)
+
+            ImpalaConnectionManager.fetch_impala_version(connection.handle)
         except Exception as ex:
             logger.debug("Connection error {}".format(ex))
             connection_ex = ex
@@ -241,7 +246,7 @@ class ImpalaConnectionManager(SQLConnectionManager):
 
         # track usage
         payload = {
-            "event_type": "dbt_impala_open",
+            "event_type": tracker.TrackingEventType.open.name,
             "auth": auth_type,
             "connection_state": connection.state,
             "elapsed_time": "{:.2f}".format(
@@ -268,7 +273,7 @@ class ImpalaConnectionManager(SQLConnectionManager):
             connection_close_end_time = time.time()
 
             payload = {
-                "event_type": "dbt_impala_close",
+                "event_type": tracker.TrackingEventType.close.name,
                 "connection_state": ConnectionState.CLOSED,
                 "elapsed_time": "{:.2f}".format(
                     connection_close_end_time - connection_close_start_time
@@ -280,6 +285,32 @@ class ImpalaConnectionManager(SQLConnectionManager):
             return connection
         except Exception as err:
             logger.debug(f"Error closing connection {err}")
+
+    @classmethod
+    def fetch_impala_version(cls, connection):
+
+        if ImpalaConnectionManager.impala_version: 
+            return ImpalaConnectionManager.impala_version
+
+        try:
+            sql = "select version()"
+            cursor = connection.cursor()
+            cursor.execute(sql)
+
+            res = cursor.fetchall()
+
+            ImpalaConnectionManager.impala_version = res[0][0].split("RELEASE")[0].strip()
+
+            tracker.populate_warehouse_info({ "version": ImpalaConnectionManager.impala_version, "build": res[0][0] })
+        except Exception as ex:
+            # we couldn't get the spark warehouse version, default to version 2
+            logger.debug(f"Cannot get impala version. Error: {ex}")
+            ImpalaConnectionManager.impala_version = "NA"
+
+            tracker.populate_warehouse_info({ "version": ImpalaConnectionManager.impala_version, "build": "NA" })
+
+        os.environ['DBT_IMPALA_VERSION'] = ImpalaConnectionManager.impala_version 
+        logger.debug(f"IMPALA VERSION {os.getenv('DBT_IMPALA_VERSION')}")
 
     @classmethod
     def get_response(cls, cursor):
@@ -329,7 +360,7 @@ class ImpalaConnectionManager(SQLConnectionManager):
 
             # track usage
             payload = {
-                "event_type": "dbt_impala_start_query",
+                "event_type": tracker.TrackingEventType.start_query.name,
                 "sql": log_sql,
                 "profile_name": self.profile.profile_name
             }
@@ -359,7 +390,7 @@ class ImpalaConnectionManager(SQLConnectionManager):
             elapsed_time = time.time() - pre
 
             payload = {
-                "event_type": "dbt_impala_end_query",
+                "event_type": tracker.TrackingEventType.end_query.name,
                 "sql": log_sql,
                 "elapsed_time": "{:.2f}".format(elapsed_time),
                 "status": query_status,

--- a/dbt/adapters/impala/impl.py
+++ b/dbt/adapters/impala/impl.py
@@ -419,7 +419,7 @@ class ImpalaAdapter(SQLAdapter):
             if not username: # username is not available when auth_type is insecure or kerberos
                 logger.debug("No username available to fetch permissions")
                 payload = {
-                    "event_type": "dbt_impala_debug_and_fetch_permissions",
+                    "event_type": tracker.TrackingEventType.debug_and_fetch_permission.name,
                     "permissions": "NA",
                 }
                 tracker.track_usage(payload)
@@ -436,37 +436,13 @@ class ImpalaAdapter(SQLAdapter):
                 permissions_json = permissions_object
 
                 payload = {
-                    "event_type": "dbt_impala_debug_and_fetch_permissions",
+                    "event_type": tracker.TrackingEventType.debug_and_fetch_permission.name,
                     "permissions": permissions_json,
                 }
                 tracker.track_usage(payload)
         except Exception as ex:
             logger.error(
                 f"Failed to fetch permissions for user: {username}. Exception: {ex}"
-            )
-            self.connections.get_thread_connection().handle.close()
-
-        # query warehouse version
-        try:
-            sql_query = "select version()"
-            _, table = self.execute(sql_query, True, True)
-            version_object = []
-            json_funcs = [c.jsonify for c in table.column_types]
-
-            for row in table.rows:
-                values = tuple(json_funcs[i](d) for i, d in enumerate(row))
-                version_object.append(OrderedDict(zip(row.keys(), values)))
-
-            version_json = version_object
-
-            payload = {
-                "event_type": "dbt_impala_warehouse",
-                "warehouse_version": version_json,
-            }
-            tracker.track_usage(payload)
-        except Exception as ex:
-            logger.error(
-                f"Failed to fetch warehouse version. Exception: {ex}"
             )
 
         self.connections.get_thread_connection().handle.close()

--- a/dbt/adapters/impala/impl.py
+++ b/dbt/adapters/impala/impl.py
@@ -419,7 +419,7 @@ class ImpalaAdapter(SQLAdapter):
             if not username: # username is not available when auth_type is insecure or kerberos
                 logger.debug("No username available to fetch permissions")
                 payload = {
-                    "event_type": tracker.TrackingEventType.debug_and_fetch_permission.name,
+                    "event_type": tracker.TrackingEventType.DEBUG,
                     "permissions": "NA",
                 }
                 tracker.track_usage(payload)
@@ -436,7 +436,7 @@ class ImpalaAdapter(SQLAdapter):
                 permissions_json = permissions_object
 
                 payload = {
-                    "event_type": tracker.TrackingEventType.debug_and_fetch_permission.name,
+                    "event_type": tracker.TrackingEventType.DEBUG,
                     "permissions": permissions_json,
                 }
                 tracker.track_usage(payload)

--- a/dbt/adapters/impala/relation.py
+++ b/dbt/adapters/impala/relation.py
@@ -42,7 +42,7 @@ class ImpalaRelation(BaseRelation):
     def __post_init__(self):
         if (self.type):
             tracker.track_usage({
-                "event_type": tracker.TrackingEventType.model_access.name,
+                "event_type": tracker.TrackingEventType.MODEL_ACCESS,
                 "model_name": self.render(),
                 "model_type": self.type,
                 "incremental_strategy": ""
@@ -54,7 +54,7 @@ class ImpalaRelation(BaseRelation):
     def log_relation(self, incremental_strategy):
         if (self.type):
             tracker.track_usage({
-                "event_type": tracker.TrackingEventType.new_incremental.name,
+                "event_type": tracker.TrackingEventType.INCREMENTAL,
                 "model_name": self.render(),
                 "model_type": self.type,
                 "incremental_strategy": incremental_strategy

--- a/dbt/adapters/impala/relation.py
+++ b/dbt/adapters/impala/relation.py
@@ -42,7 +42,7 @@ class ImpalaRelation(BaseRelation):
     def __post_init__(self):
         if (self.type):
             tracker.track_usage({
-                "event_type": "dbt_impala_model_access",
+                "event_type": tracker.TrackingEventType.model_access.name,
                 "model_name": self.render(),
                 "model_type": self.type,
                 "incremental_strategy": ""
@@ -54,7 +54,7 @@ class ImpalaRelation(BaseRelation):
     def log_relation(self, incremental_strategy):
         if (self.type):
             tracker.track_usage({
-                "event_type": "dbt_impala_new_incremental",
+                "event_type": tracker.TrackingEventType.new_incremental.name,
                 "model_name": self.render(),
                 "model_type": self.type,
                 "incremental_strategy": incremental_strategy


### PR DESCRIPTION
## Describe your changes
* modify populate_unique_ids to provide optional userkey
* refactor warehouse key, add event type enums
* use the refactored tracking lib: event type, warehouse version 

## Testing:
Using dbt debug, a sample tacking payload in dbt.logs:
<pre>
14:39:42.232590 [debug] [MainThread]: Tracker adapter: Sending Event {'data': '{"event_type": "close", "connection_state": "closed", "elapsed_time": "0.00", "auth": "N/A", "incremental_strategy": "N/A", "model_name": "N/A", "model_type": "N/A", "permissions": "N/A", "profile_name": "N/A", "sql_type": "N/A", "id": "de0426cc-1ef7-4b5e-9b21-10509264ebae", "unique_host_hash": "a80df3703d95f6c576ac4c680a231390", "unique_user_hash": "e8a5d78ea632435d797d3d58df650872", "unique_session_hash": "81adc06a71ea48ebb780a9a8e78c5fcf", "python_version": "3.9.12", "system": "Darwin", "machine": "arm64", "platform": "macOS-12.6-arm64-arm-64bit", "dbt_version": "1.3.0", "dbt_adapter": "impala-1.3.0", "dbt_deployment_env": {"env": "yarn", "version": "1.2.0"}, "project_name": "dbtdemo", "target_name": "cloudera-cia-impala_ldap", "no_of_threads": 1, "warehouse_version": {"version": "impalad version 4.0.0-SNAPSHOT", "build": "impalad version 4.0.0-SNAPSHOT RELEASE (build e8e9c674f449956419d983d20e5a4abc77b383d0)\\nBuilt on Sat May 14 07:50:13 UTC 2022"}}'}
</pre>