### PR TITLE
split dbt_adapter field in instrumentation to dbt_adapter_type and dbt_adapter_version

### DIFF
--- a/dbt/adapters/impala/cloudera_tracking.py
+++ b/dbt/adapters/impala/cloudera_tracking.py
@@ -65,7 +65,8 @@ def populate_platform_info(cred: Credentials, ver):
         "dbt_version"
     ] = dbt.version.get_installed_version().to_version_string(skip_matcher=True)
     # dbt adapter info e.g. impala-1.2.0
-    platform_info["dbt_adapter"] = f"{cred.type}-{ver.version}"
+    platform_info["dbt_adapter_type"] = f"{cred.type}"
+    platform_info["dbt_adapter_version"] = f"{ver.version}"
 
 def populate_dbt_deployment_env_info():
     """


### PR DESCRIPTION
split dbt_adapter field in instrumentation to dbt_adapter_type and dbt_adapter_version

Test Result:
{'data': '{"event_type": "dbt_impala_close", "connection_state": "closed", "elapsed_time": "0.00", "auth": "N/A", "incremental_strategy": "N/A", "model_name": "N/A", "model_type": "N/A", "permissions": "N/A", "profile_name": "N/A", "sql_type": "N/A", "id": "0deb7d68-d2fd-488c-b4eb-3e72fa99856b", "unique_host_hash": "a80df3703d95f6c576ac4c680a231390", "unique_user_hash": "e8a5d78ea632435d797d3d58df650872", "unique_session_hash": "b0828c493ae03270080489765f1a814d", "python_version": "3.10.7", "system": "Darwin", "machine": "arm64", "platform": "macOS-13.0.1-arm64-arm-64bit", "dbt_version": "1.3.1", **"dbt_adapter_type": "impala", "dbt_adapter_version": "1.3.0"**, "dbt_deployment_env": {}, "project_name": "dbt_impala_demo", "target_name": "cloudera_cia_dbt_impala_demo", "no_of_threads": 4}'}
