### PR TITLE
Plain authorization support

### DIFF
--- a/dbt/adapters/impala/connections.py
+++ b/dbt/adapters/impala/connections.py
@@ -224,6 +224,20 @@ class ImpalaConnectionManager(SQLConnectionManager):
                     retries=credentials.retries,
                 )
                 auth_type = "kerberos"
+            elif (
+                    credentials.auth_type == "PLAIN"
+                    or credentials.auth_type == "plain"
+            ):  # plain type connection
+                handle = impala.dbapi.connect(
+                    host=credentials.host,
+                    port=credentials.port,
+                    auth_mechanism="PLAIN",
+                    use_ssl=credentials.use_ssl,
+                    user=credentials.username,
+                    password=credentials.password,
+                    retries=credentials.retries,
+                )
+                auth_type = "plain"
             else:  # default, insecure connection
                 handle = impala.dbapi.connect(
                     host=credentials.host,

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
         'dbt-core~={}'.format(dbt_core_version),
         "impyla==0.18",
         "python-decouple>=3.6",
-        "kerberos>=1.3.0",
+        # "kerberos>=1.3.0", # Not required per README, doesn't work on Windows
     ],
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
## Describe your changes
Add support for [plain authorization](https://github.com/cloudera/impyla/blob/0f2be72e31feab9cc6d91b44dc873af306bcb97a/impala/dbapi.py#L71) & fix minor issue with requirements on Windows.

## Internal Jira ticket number or external issue link
Issue #140 

## Testing procedure/screenshots(if appropriate):
Tested connection to Impala server using plain authorization, which worked. I can provide screenshots upon request.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have formatted my added/modified code to follow pep-8 standards
- [x] I have checked suggestions from python linter to make sure code is of good quality.
