### PR TITLE
ability to create Iceberg V1 and V2 tables

### DIFF
--- a/dbt/adapters/impala/.env
+++ b/dbt/adapters/impala/.env
@@ -1,0 +1,5 @@
+# modify and copy this file to dbt/adapters/impala/.env
+SNOWPLOW_ENDPOINT=[https://events-end-point-url.com/events]
+SNOWPLOW_TIMEOUT=10
+SNOWPLOW_API_KEY=[xyzSECRECT_KEYxyz]
+SNOWPLOW_ENV=prod

--- a/dbt/adapters/impala/.env
+++ b/dbt/adapters/impala/.env
@@ -1,5 +1,0 @@
-# modify and copy this file to dbt/adapters/impala/.env
-SNOWPLOW_ENDPOINT=[https://events-end-point-url.com/events]
-SNOWPLOW_TIMEOUT=10
-SNOWPLOW_API_KEY=[xyzSECRECT_KEYxyz]
-SNOWPLOW_ENV=prod

--- a/dbt/include/impala/macros/adapters.sql
+++ b/dbt/include/impala/macros/adapters.sql
@@ -149,6 +149,7 @@
 
   {%- set sql_header = config.get('sql_header', none) -%}
   {%- set is_external = config.get('external') -%}
+  {%- set is_iceberg = config.get('is_iceberg') -%}
 
   {{ sql_header if sql_header is not none }}
 
@@ -159,6 +160,7 @@
     {{ ct_option_comment_relation(label="comment") }}
     {{ ct_option_row_format(label="row format") }}
     {{ ct_option_with_serdeproperties(label="with serdeproperties") }}
+    {% if is_iceberg == true -%} STORED BY ICEBERG {%- endif %}
     {{ ct_option_stored_as(label="stored as") }}
     {{ ct_option_location_clause(label="location") }} 
     {{ ct_option_cached_in(label="cached in") }}


### PR DESCRIPTION
## Describe your changes
Hello Team, 
We have added the following code changes

- ability to create iceberg table e.g stored by iceberg will be inserted if is_iceberg is set to true
- By passing the tbl_properties we can choose V1 or V2 iceberg table `tbl_properties="('format-version'='2')"`

## Internal Jira ticket number or external issue link
https://jira.cloudera.com/browse/DBT-671 
## Testing procedure/screenshots(if appropriate):


## Checklist before requesting a review
- [Yes ] I have performed a self-review of my code
- [ Notsure ] I have formatted my added/modified code to follow pep-8 standards
- [ Yes ] I have checked suggestions from python linter to make sure code is of good quality.
