### PR TITLE
Catch "Could not resolve path" error if table is not found.

### DIFF
--- a/dbt/adapters/impala/impl.py
+++ b/dbt/adapters/impala/impl.py
@@ -164,8 +164,8 @@ class ImpalaAdapter(SQLAdapter):
             except dbt.exceptions.RuntimeException as e:
                 # impala would throw error when table doesn't exist
                 errmsg = getattr(e, "msg", "")
-                if "Table or view not found" in errmsg or "NoSuchTableException" in errmsg:
-                    pass
+                if "Table or view not found" in errmsg or "NoSuchTableException" in errmsg or "Could not resolve path" in errmsg:
+                    return []
                 else:
                     raise e
 
@@ -396,4 +396,4 @@ class ImpalaAdapter(SQLAdapter):
         Not used to validate custom strategies defined by end users.
         """
         return ["append", "insert_overwrite"]
-        
+ 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,3 +23,4 @@ impala_ldap = {
 @pytest.fixture(scope="class")
 def dbt_profile_target():
     return impala_ldap
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,15 +8,14 @@ pytest_plugins = ["dbt.tests.fixtures.project"]
 impala_ldap = {
         'type': 'impala',
         'threads': 4,
-        'schema': 'dbt_adapter_test',
-        'host':  os.getenv('IMPALA_HOST'),
-        'http_path': os.getenv('IMPALA_HTTP_PATH'),
-        'port': int(os.getenv('IMPALA_PORT')),
-        'auth_type': 'ldap',
-        'use_http_transport': True,
-        'use_ssl': True,
-        'user': os.getenv('IMPALA_USER'),
-        'password': os.getenv('IMPALA_PASSWORD')
+        'host':  os.getenv('IMPALA_HOST') or 'localhost',
+        'http_path': os.getenv('IMPALA_HTTP_PATH') or '',
+        'port': int(os.getenv('IMPALA_PORT') or 21050),
+        'auth_type': os.getenv('AUTH_TYPE') or '',
+        'use_http_transport': os.getenv('USE_HTTP_TRANSPORT') or False,
+        'use_ssl': os.getenv('USE_SSL') or False,
+        'user': os.getenv('IMPALA_USER') or '',
+        'password': os.getenv('IMPALA_PASSWORD') or ''
     }
 
 # The profile dictionary, used to write out profiles.yml
@@ -24,4 +23,3 @@ impala_ldap = {
 @pytest.fixture(scope="class")
 def dbt_profile_target():
     return impala_ldap
-


### PR DESCRIPTION
## Describe your changes
If a table is not found in the path, impala throws a "Could not resolve path" error. Catching the error and returning empty array in get_columns_in_relation()

## Internal Jira ticket number or external issue link

https://jira.cloudera.com/browse/DBT-675

## Testing procedure/screenshots(if appropriate):
https://gist.github.com/vamshikolanu/30ed615ad5e79c41e0a600f190c71abc

## Checklist before requesting a review
- [ Y] I have performed a self-review of my code
- [ Y] I have formatted my added/modified code to follow pep-8 standards
- [ ] I have checked suggestions from python linter to make sure code is of good quality.
