### PR TITLE
DBT-675: Catch "Could not resolve path" error if table is not found.

### DIFF
--- a/dbt/adapters/impala/impl.py
+++ b/dbt/adapters/impala/impl.py
@@ -164,8 +164,8 @@ class ImpalaAdapter(SQLAdapter):
             except dbt.exceptions.RuntimeException as e:
                 # impala would throw error when table doesn't exist
                 errmsg = getattr(e, "msg", "")
-                if "Table or view not found" in errmsg or "NoSuchTableException" in errmsg:
-                    pass
+                if "Table or view not found" in errmsg or "NoSuchTableException" in errmsg or "Could not resolve path" in errmsg:
+                    return []
                 else:
                     raise e
 

--- a/tests/functional/adapter/test_basic.py
+++ b/tests/functional/adapter/test_basic.py
@@ -111,7 +111,6 @@ class TestSnapshotCheckColsImpala(BaseSnapshotCheckCols):
 class TestSnapshotTimestampImpala(BaseSnapshotTimestamp):
     pass
 
-@pytest.mark.skip(reason="Not working from the start ie v1.3.3")
 class TestBaseAdapterMethod(BaseAdapterMethod):
     pass
 


### PR DESCRIPTION
## Describe your changes
If a table is not found in the path, impala throws a "Could not resolve path" error. Catching the error and returning empty array in get_columns_in_relation()

## Internal Jira ticket number or external issue link:
https://jira.cloudera.com/browse/DBT-675


## Testing procedure/screenshots(if appropriate):
https://gist.github.com/vamshikolanu/30ed615ad5e79c41e0a600f190c71abc

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have formatted my added/modified code to follow pep-8 standards
- [ ] I have checked suggestions from python linter to make sure code is of good quality.
