### PR TITLE
Support for handling iceberg partition tables 

### DIFF
--- a/dbt/include/impala/macros/adapters.sql
+++ b/dbt/include/impala/macros/adapters.sql
@@ -155,7 +155,11 @@
 
   create {% if is_external == true -%}external{%- endif %} table
     {{ relation.include(schema=true) }}
-    {{ ct_option_partition_cols(label="partitioned by") }}
+    {% if is_iceberg == true -%}
+      {{ ct_option_partition_cols(label="partitioned by spec") }}
+    {% else %}
+      {{ ct_option_partition_cols(label="partitioned by") }}
+    {%- endif %}
     {{ ct_option_sort_cols(label="sort by") }}
     {{ ct_option_comment_relation(label="comment") }}
     {{ ct_option_row_format(label="row format") }}


### PR DESCRIPTION
## Describe your changes
For iceberg partitioned table, we need to use the **_partitioned by spec_**  clause rather than **_partitioned by_**.  Also added/updated the functional test for partition by clause within format_iceberg


## Internal Jira ticket number or external issue link
https://jira.cloudera.com/browse/DBT-683

## Testing procedure/screenshots(if appropriate):
Functional test run https://gist.github.com/niteshy/19532211b262eed12f45db04ffd738a2 

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have formatted my added/modified code to follow pep-8 standards
- [ ] I have checked suggestions from python linter to make sure code is of good quality.
