### PR TITLE
DBT-680: Fixing the functional test for utils, key is reserve keywords

### DIFF
--- a/tests/functional/adapter/test_utils.py
+++ b/tests/functional/adapter/test_utils.py
@@ -453,10 +453,10 @@ data_output as (
 calculate as (
 
     select
-        key,
+        key_column,
         {{ bool_or('val1 = val2') }} as value
     from util_data
-    group by key
+    group by key_column
 
 )
 
@@ -465,7 +465,7 @@ select
     data_output.value as expected
 from calculate
 left join data_output
-on calculate.key = data_output.key
+on calculate.key_column = data_output.key_column
 """
 
 class TestBoolOr(BaseBoolOr):


### PR DESCRIPTION
## Describe your changes
test_utils.py has broken test TestBoolOr because column named `key` is a reserve keywords in impala. 
Hence, rename the column to key_column  

## Internal Jira ticket number or external issue link
https://jira.cloudera.com/browse/DBT-680

## Testing procedure/screenshots(if appropriate):
https://gist.github.com/niteshy/0bd9ce5425c8b964afdf1bb17ec1e10c

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have formatted my added/modified code to follow pep-8 standards
- [ ] I have checked suggestions from python linter to make sure code is of good quality.
