### PR TITLE
DBT-686: Fix duplicate columns issue in get_columns_in_relation() function.

### DIFF
--- a/tests/functional/adapter/test_basic.py
+++ b/tests/functional/adapter/test_basic.py
@@ -100,6 +100,19 @@ class TestIncrementalImpala(BaseIncremental):
         assert len(catalog.nodes) == 3
         assert len(catalog.sources) == 1
 
+incremental_partitionby_sql = """
+ {{ config(materialized="incremental", partition_by="id_partition") }}
+ select *, id as id_partition from {{ source('raw', 'seed') }}
+ {% if is_incremental() %}
+ where id > (select max(id) from {{ this }})
+ {% endif %}
+""".strip()
+
+class TestIncrementalWithPartitionImpala(TestIncrementalImpala):
+   @pytest.fixture(scope="class")
+   def models(self):
+        return {"incremental_test_model.sql": incremental_partitionby_sql, "schema.yml": schema_base_yml}
+
 class TestGenericTestsImpala(BaseGenericTests):
     pass
 

--- a/tests/functional/adapter/test_basic.py
+++ b/tests/functional/adapter/test_basic.py
@@ -100,7 +100,7 @@ class TestIncrementalImpala(BaseIncremental):
         assert len(catalog.nodes) == 3
         assert len(catalog.sources) == 1
 
-incremental_partitionby_sql = """
+incremental_single_partitionby_sql = """
  {{ config(materialized="incremental", partition_by="id_partition") }}
  select *, id as id_partition from {{ source('raw', 'seed') }}
  {% if is_incremental() %}
@@ -108,10 +108,24 @@ incremental_partitionby_sql = """
  {% endif %}
 """.strip()
 
-class TestIncrementalWithPartitionImpala(TestIncrementalImpala):
+class TestIncrementalWithSinglePartitionKeyImpala(TestIncrementalImpala):
    @pytest.fixture(scope="class")
    def models(self):
-        return {"incremental_test_model.sql": incremental_partitionby_sql, "schema.yml": schema_base_yml}
+        return {"incremental_test_model.sql": incremental_single_partitionby_sql, "schema.yml": schema_base_yml}
+
+incremental_multiple_partitionby_sql = """
+ {{ config(materialized="incremental", partition_by=["id_partition1", "id_partition2"]) }}
+ select *, id as id_partition1, id as id_partition2 from {{ source('raw', 'seed') }}
+ {% if is_incremental() %}
+ where id > (select max(id) from {{ this }})
+ {% endif %}
+""".strip()
+
+class TestIncrementalWithMultiplePartitionKeyImpala(TestIncrementalImpala):
+   @pytest.fixture(scope="class")
+   def models(self):
+        return {"incremental_test_model.sql": incremental_multiple_partitionby_sql, "schema.yml": schema_base_yml}
+
 
 class TestGenericTestsImpala(BaseGenericTests):
     pass


### PR DESCRIPTION
## Describe your changes
Currently, get_columns_in_relation() fn is returning duplicate columns as it's not parsing the partition column information. Made changes to this function to handle this scenario. Also added functional tests to handle incremental partition tables. 


## Internal Jira ticket number or external issue link:
https://jira.cloudera.com/browse/DBT-686

## Testing procedure/screenshots(if appropriate):
Complete test run: https://gist.github.com/vamshikolanu/f24fa9d5c607fd6eb780e58c2d4b69df
TestIncrementalWithPartitionImpala verbose test run: https://gist.github.com/vamshikolanu/6b9422d3ffef8e2d6a3d15af2f3904fa

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have formatted my added/modified code to follow pep-8 standards
- [ ] I have checked suggestions from python linter to make sure code is of good quality.
