### PR TITLE
DBT-690: Fix insert clause for iceberg table format

### DIFF
--- a/dbt/include/impala/macros/insertoverwrite.sql
+++ b/dbt/include/impala/macros/insertoverwrite.sql
@@ -62,12 +62,21 @@
 
         {%- set dest_cols_csv = get_quoted_csv_exclude(dest_columns | map(attribute="name"), "") -%}
         {%- set dest_cols_csv_exclude = get_quoted_csv_exclude(dest_columns | map(attribute="name"), partition_col) -%}
+	
+	{% if is_iceberg == true -%}
+            insert into {{ target }} ({{ dest_cols_csv }}) partition({{ partition_col }})
+            (
+              select {{ dest_cols_csv }}
+              from {{ source }}
+            )
+        {% else %}	
+            insert into {{ target }} ({{ dest_cols_csv_exclude }}) partition({{ partition_col }})
+            (
+              select {{ dest_cols_csv }}
+              from {{ source }}
+            )
+        {%- endif %}
 
-        insert into {{ target }} ({{ dest_cols_csv_exclude }}) partition({{ partition_col }})
-        (
-            select {{ dest_cols_csv }}
-            from {{ source }}
-        )
     {% else %}
         {%- set dest_cols_csv = get_quoted_csv_exclude(dest_columns | map(attribute="name"), "") -%}
 


### PR DESCRIPTION
## Describe your changes
Insert clause of iceberg expects same number of columns present in the select clause. Modified the query accordingly. 

## Internal Jira ticket number or external issue link
https://jira.cloudera.com/browse/DBT-690

## Testing procedure/screenshots(if appropriate):
Basic tests: https://gist.github.com/vamshikolanu/3c6021be163ff951c13a57cb95c55053
Iceberg tests: https://gist.github.com/vamshikolanu/545d281ea57a7e71cc5f8919c3e62421


## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have formatted my added/modified code to follow pep-8 standards
- [ ] I have checked suggestions from python linter to make sure code is of good quality.
