### PR TITLE
DBT-691: Insert queries doesn't need explicit column list

### DIFF
--- a/dbt/include/impala/macros/insertoverwrite.sql
+++ b/dbt/include/impala/macros/insertoverwrite.sql
@@ -14,62 +14,38 @@
 # limitations under the License.
 #}
 
-{% macro get_quoted_csv_exclude(column_names, exclude_name) %}
-
-    {% set quoted = [] %}
-    {% for col in column_names -%}
-        {% if exclude_name|string() != col|string() %}
-           {%- do quoted.append(adapter.quote(col)) -%}
-        {% endif %}
-    {%- endfor %}
-
-    {%- set dest_cols_csv = quoted | join(', ') -%}
-    {{ return(dest_cols_csv) }}
-
-{% endmacro %}
-
 {% macro get_insert_overwrite_sql(target, source, dest_columns) -%}
 
     {% set raw_strategy = config.get('incremental_strategy') or 'append' %}
     {%- set partition_cols = config.get('partition_by', validator=validation.any[list]) -%}
-    {% set is_iceberg = config.get('iceberg') %}
-    
-    {% if partition_cols is not none and raw_strategy == 'insert_overwrite' %}
+    {%- set dest_cols_csv = dest_columns | map(attribute="name") | join(", ") -%}
+
+    {% if partition_cols is not none %}
         {% if partition_cols is string %}
-           {%- set partition_col = partition_cols -%}
+            {%- set partition_cols_csv = partition_cols -%}
         {% else %}
-           {%- set partition_col = partition_cols[0] -%}
+            {%- set partition_cols_csv = partition_cols | join(", ") -%}
         {% endif %}
+        {{ print("partition_cols_csv = " + partition_cols_csv) }}
 
-        {%- set dest_cols_csv = get_quoted_csv_exclude(dest_columns | map(attribute="name"), "") -%}
-        {%- set dest_cols_csv_exclude = get_quoted_csv_exclude(dest_columns | map(attribute="name"), partition_col) -%}
+        {% if raw_strategy == 'insert_overwrite' %}
 
-	{% if is_iceberg == true -%}
-            insert overwrite {{ target }} ({{ dest_cols_csv }}) partition({{ partition_col }})
+            insert overwrite {{ target }} partition({{ partition_cols_csv }}) 
+            (
                 select {{ dest_cols_csv }}
                 from {{ source }}
-        {% else %}
-            insert overwrite {{ target }} ({{ dest_cols_csv_exclude }}) partition({{ partition_col }})
+            )
+
+        {% elif raw_strategy == 'append' %}
+
+            insert into {{ target }} partition({{ partition_cols_csv }})
+            (
                 select {{ dest_cols_csv }}
                 from {{ source }}
-        {%- endif %}
-    {% elif partition_cols is not none and raw_strategy == 'append' %}
-        {% if partition_cols is string %}
-           {%- set partition_col = partition_cols -%}
-        {% else %}
-           {%- set partition_col = partition_cols[0] -%}
+            )
+
         {% endif %}
-
-        {%- set dest_cols_csv = get_quoted_csv_exclude(dest_columns | map(attribute="name"), "") -%}
-        {%- set dest_cols_csv_exclude = get_quoted_csv_exclude(dest_columns | map(attribute="name"), partition_col) -%}
-
-        insert into {{ target }} ({{ dest_cols_csv_exclude }}) partition({{ partition_col }})
-        (
-            select {{ dest_cols_csv }}
-            from {{ source }}
-        )
     {% else %}
-        {%- set dest_cols_csv = get_quoted_csv_exclude(dest_columns | map(attribute="name"), "") -%}
 
         insert into {{ target }} ({{ dest_cols_csv }})
         (


### PR DESCRIPTION
## Describe your changes
In the insert query, we don't need to provide an explicit column list. The nested select already has the column list for the insert. Removed the unused macro too

This will simplify the conditions for iceberg and other queries

## Internal Jira ticket number or external issue link
https://jira.cloudera.com/browse/DBT-691

## Testing procedure/screenshots(if appropriate):
https://gist.github.com/niteshy/b2f08880496b344940a6a1b04ddb9bc9 


## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have formatted my added/modified code to follow pep-8 standards
- [ ] I have checked suggestions from python linter to make sure code is of good quality.
