### PR TITLE
DBT-692: Renaming the iceberg flag from boolean to table_type = iceberg

### DIFF
--- a/dbt/include/impala/macros/adapters.sql
+++ b/dbt/include/impala/macros/adapters.sql
@@ -149,13 +149,13 @@
 
   {%- set sql_header = config.get('sql_header', none) -%}
   {%- set is_external = config.get('external') -%}
-  {%- set is_iceberg = config.get('iceberg') -%}
+  {%- set table_type = config.get('table_type') -%}
 
   {{ sql_header if sql_header is not none }}
 
   create {% if is_external == true -%}external{%- endif %} table
     {{ relation.include(schema=true) }}
-    {% if is_iceberg == true -%}
+    {% if table_type == 'iceberg' -%}
       {{ ct_option_partition_cols(label="partitioned by spec") }}
     {% else %}
       {{ ct_option_partition_cols(label="partitioned by") }}
@@ -164,7 +164,7 @@
     {{ ct_option_comment_relation(label="comment") }}
     {{ ct_option_row_format(label="row format") }}
     {{ ct_option_with_serdeproperties(label="with serdeproperties") }}
-    {% if is_iceberg == true -%} STORED BY ICEBERG {%- endif %}
+    {%- if table_type == 'iceberg' -%} STORED BY ICEBERG {%- endif -%}
     {{ ct_option_stored_as(label="stored as") }}
     {{ ct_option_location_clause(label="location") }} 
     {{ ct_option_cached_in(label="cached in") }}

--- a/tests/functional/adapter/test_icerberg_format.py
+++ b/tests/functional/adapter/test_icerberg_format.py
@@ -46,7 +46,7 @@ iceberg_base_table_sql = """
 {{
   config(
     materialized="table",
-    iceberg=true
+    table_type="iceberg"
   )
 }}""".strip() + model_base
 
@@ -54,7 +54,7 @@ iceberg_base_materialized_var_sql = """
 {{ 
   config(
     materialized=var("materialized_var", "table"),
-    iceberg=true
+    table_type="iceberg"
   )
 }}""".strip() + model_base
 
@@ -62,7 +62,7 @@ incremental_iceberg_sql = """
  {{
     config(
         materialized="incremental",
-        iceberg=true
+        table_type="iceberg"
     )
 }}
 """.strip() + model_incremental
@@ -73,7 +73,7 @@ incremental_partition_iceberg_sql = """
     config(
         materialized="incremental",
         partition_by="id_partition1",
-        iceberg=true
+        table_type="iceberg"
     )
 }}
 select *, id as id_partition1 from {{ source('raw', 'seed') }}
@@ -87,7 +87,7 @@ incremental_multiple_partition_iceberg_sql = """
     config(
         materialized="incremental",
         partition_by=["id_partition1", "id_partition2"],
-        iceberg=true
+        table_type="iceberg"
     )
 }}
 select *, id as id_partition1, id as id_partition2 from {{ source('raw', 'seed') }}
@@ -102,7 +102,7 @@ insertoverwrite_iceberg_sql = """
         materialized="incremental",
         incremental_strategy="insert_overwrite",
         partition_by="id_partition1",
-        iceberg=true
+        table_type="iceberg"
     )
 }}
 select *, id as id_partition1 from {{ source('raw', 'seed') }}


### PR DESCRIPTION
## Describe your changes
Rather than using a boolean flag **iceberg = true** in the configuration, we should use **table_type = "iceberg"** 

## Internal Jira ticket number or external issue link
https://jira.cloudera.com/browse/DBT-692

## Testing procedure/screenshots(if appropriate):
https://gist.github.com/niteshy/3b96b876f162ab90b9c03087166a8441

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have formatted my added/modified code to follow pep-8 standards
- [ ] I have checked suggestions from python linter to make sure code is of good quality.
