### PR TITLE
DBT-698: Fixing the ParseException in UA, via removing the semicolon at the end of query

### DIFF
--- a/dbt/include/impala/macros/adapters.sql
+++ b/dbt/include/impala/macros/adapters.sql
@@ -171,7 +171,6 @@
     {{ ct_option_tbl_properties(label="tblproperties") }}
   as
     {{ sql }}
-  ;
 {%- endmacro %}
 
 {% macro impala__create_view_as(relation, sql) -%}
@@ -186,7 +185,6 @@
     {{ ct_option_comment_relation(label="comment") }}
   as
     {{ sql }}
-  ;
 {%- endmacro %}
 
 {% macro impala__create_schema(relation) -%}
@@ -257,7 +255,7 @@
     drop table if exists {{ to_relation }}
   {% endcall %}
   {% call statement('drop_relation_if_exists_view') %}
-    drop view if exists {{ to_relation }};
+    drop view if exists {{ to_relation }}
   {% endcall %}
   {% call statement('rename_relation') -%}
     {% if not from_rel_type %}


### PR DESCRIPTION
## Describe your changes
Even though the queries ending with semicolon works for Impala without UA but they fails with ParseException in UA 
Hence, removed the ending semicolon for all queries. 

## Internal Jira ticket number or external issue link
[DBT-698](https://jira.cloudera.com/browse/DBT-698)

## Testing procedure/screenshots(if appropriate):
Verified no regression in impala (without UA) https://gist.github.com/niteshy/9657cc0a52515e5f8f90b6f52a0e9541 
Verified the ParseException is fixed, but there are SemanticException https://gist.github.com/niteshy/a01837d9dc1dbbfe760e40c6df967d9c, which is separate issue [DBT-699](https://jira.cloudera.com/browse/DBT-699)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have formatted my added/modified code to follow pep-8 standards
- [x] I have checked suggestions from python linter to make sure code is of good quality.
