### PR TITLE
DBT-750: Drop temp tables create as part of incremental strategy

### DIFF
--- a/dbt/include/impala/macros/incremental.sql
+++ b/dbt/include/impala/macros/incremental.sql
@@ -99,6 +99,7 @@
       {% set need_swap = true %}
   {% else %}
     {% do run_query(get_create_table_as_sql(True, temp_relation, sql)) %}
+    {% do to_drop.append(temp_relation) %}
     {% do adapter.expand_target_column_types(
              from_relation=temp_relation,
              to_relation=target_relation) %}


### PR DESCRIPTION
## Describe your changes
Impala doesn't support the creation of temp tables. As part of this change, dropping the temp table that get part of incremental strategy

## Internal Jira ticket number or external issue link
https://jira.cloudera.com/browse/DBT-750

## Testing procedure/screenshots(if appropriate):
Before - No drop table statement here: https://gist.github.com/vamshikolanu/71976afa8969b2b828abdb5f728ad1be#file-gistfile1-txt-L700
After: https://gist.github.com/vamshikolanu/6bcde91db9369a94d7d5ec94cb1d0460#file-gistfile1-txt-L700

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have formatted my added/modified code to follow pep-8 standards
- [x] I have checked suggestions from python linter to make sure code is of good quality.
