### PR TITLE
DBT-758: Raise the exception if the metadata scan failed for any table

### DIFF
--- a/dbt/adapters/impala/__version__.py
+++ b/dbt/adapters/impala/__version__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version = "1.4.1"
+version = "1.4.2"

--- a/dbt/adapters/impala/connections.py
+++ b/dbt/adapters/impala/connections.py
@@ -257,7 +257,7 @@ class ImpalaConnectionManager(SQLConnectionManager):
 
             ImpalaConnectionManager.fetch_impala_version(connection.handle)
         except Exception as ex:
-            logger.debug(f"Connection error {ex}")
+            logger.error(f"Connection error {ex}")
             connection_ex = ex
             connection.state = ConnectionState.FAIL
             connection.handle = None

--- a/dbt/adapters/impala/impl.py
+++ b/dbt/adapters/impala/impl.py
@@ -108,8 +108,8 @@ class ImpalaAdapter(SQLAdapter):
                 return []
             else:
                 description = "Error while retrieving information about"
-                logger.debug(f"{description} {schema_relation}: {e.msg}")
-                return []
+                logger.error(f"{description} {schema_relation}: {e.msg}")
+                raise e
 
         relations = []
         for row in results:

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ def _get_dbt_core_version():
 
 package_name = "dbt-impala"
 # make sure this always matches dbt/adapters/dbt_impala/__version__.py
-package_version = "1.4.1"
+package_version = "1.4.2"
 description = """The Impala adapter plugin for dbt"""
 
 dbt_core_version = _get_dbt_core_version()


### PR DESCRIPTION
## Describe your changes
We found that during the metadata scan if the _describe_ statement one of the table(/s) is failed then the metadata information for all tables is lost. DBT assumes that none of these tables exists. This causes the models to run as a first run of an incremental strategy and try to create a table. This results in unwanted cascading errors. 

To resolve such issues, we should throw or raise the exception the first time when we see the error in the _describe_ commands. 

## Internal Jira ticket number or external issue link
https://jira.cloudera.com/browse/DBT-758

## Testing procedure/screenshots(if appropriate):
https://gist.github.com/niteshy/f56c91638739b12978a5164ae310fa49

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have formatted my added/modified code to follow pep-8 standards
- [x] I have checked suggestions from python linter to make sure code is of good quality.
