### PR TITLE
DBT-761: Updating .gitignore to use .venv* instead of .venv/ for consistency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,5 @@ __pycache__/
 *.log
 logs/
 .env
-.venv/
+.venv*
 test.env


### PR DESCRIPTION
## Describe your changes
The current .gitignore uses `.venv/` to exclude the virtual environment directory, but it seems to be ineffective in preventing the tracking of files within the .venv directory. To address this issue and ensure proper exclusion, this pull request suggests updating the .gitignore file to use the pattern `.venv*`. 
## Internal Jira ticket number or external issue link
https://jira.cloudera.com/browse/DBT-761
## Testing procedure/screenshots(if appropriate):
[gitignore_gist.txt](https://gist.github.com/nsharma-25/3856b1fe131b689989f931c686c4405b#file-gitignore_gist-txt)
## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have formatted my added/modified code to follow pep-8 standards
- [x] I have checked suggestions from python linter to make sure code is of good quality.
