### PR TITLE
DBT-772: Upgrade dbt-impala adapter to use v1.6 dbt-core

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,10 @@ PROFILE := dwx_endpoint
 CHANGED_FILES := $(shell git ls-files --modified --other --exclude-standard)
 CHANGED_FILES_IN_BRANCH := $(shell git diff --name-only $(shell git merge-base origin/master HEAD))
 
-.PHONY: all install prepare-env functional_test test clean help
+.PHONY: all install dev_setup functional_test test clean help
 .PHONY: pre-commit pre-commit-in-branch pre-commit-all
 
-all: prepare-env test  ## Default target for dev setup and run tests.
+all: dev_setup test  ## Default target for dev setup and run tests.
 
 # Required python3 already installed in the system
 $(VENV)/bin/activate:
@@ -24,7 +24,7 @@ install: $(VENV)/bin/activate dev-requirements.txt	## Install all dependencies.
 	$(VENV)/bin/python3 -m pip install --upgrade pip
 	$(VENV)/bin/pip install -e . -r dev-requirements.txt
 
-prepare-env: $(VENV)/bin/activate	 ## Install all dependencies and setup pre-commit.
+dev_setup: $(VENV)/bin/activate	 ## Install all dependencies and setup pre-commit.
 	@\
 	make install
 	$(VENV)/bin/pre-commit install

--- a/dbt/adapters/impala/__version__.py
+++ b/dbt/adapters/impala/__version__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version = "1.4.3"
+version = "1.5.0"

--- a/dbt/adapters/impala/__version__.py
+++ b/dbt/adapters/impala/__version__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version = "1.5.0"
+version = "1.6.0"

--- a/dbt/include/impala/macros/utils/datediff.sql
+++ b/dbt/include/impala/macros/utils/datediff.sql
@@ -108,17 +108,6 @@
                 + millisecond({{org_second_date}})
                 - millisecond({{org_first_date}})
             {% endif %}
-
-            {% if datepart == 'microsecond' %}
-                {% set capture_str = '[0-9]{4}-[0-9]{2}-[0-9]{2}.[0-9]{2}:[0-9]{2}:[0-9]{2}.([0-9]{6})' %}
-                -- Impala doesn't really support microseconds extration from timestamp, eventhough there is microsecond_add/sub
-                -- So this is a massive hack!
-                -- It will only work if the timestamp-string is of the format
-                -- 'yyyy-MM-dd-HH mm.ss.SSSSSS'
-                + cast(regexp_extract(cast(cast({{second_date}} as timestamp) as string), '{{capture_str}}', 1) as bigint)
-                - cast(regexp_extract(cast(cast({{first_date}} as timestamp) as string), '{{capture_str}}', 1) as bigint)
-            {% endif %}
-
     {%- else -%}
 
         {{ exceptions.raise_compiler_error("macro datediff not implemented for datepart ~ '" ~ datepart ~ "' ~ on Impala") }}

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
-dbt-tests-adapter==1.4.*
+dbt-tests-adapter==1.5.*
 pre-commit~=2.21;python_version=="3.7"
 pre-commit~=3.2;python_version>="3.8"
 pytest

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
-dbt-tests-adapter==1.5.*
+dbt-tests-adapter==1.6.*
 pre-commit~=2.21;python_version=="3.7"
 pre-commit~=3.2;python_version>="3.8"
 pytest

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ def _get_dbt_core_version():
 
 package_name = "dbt-impala"
 # make sure this always matches dbt/adapters/dbt_impala/__version__.py
-package_version = "1.4.3"
+package_version = "1.5.0"
 description = """The Impala adapter plugin for dbt"""
 
 dbt_core_version = _get_dbt_core_version()

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ def _get_dbt_core_version():
 
 package_name = "dbt-impala"
 # make sure this always matches dbt/adapters/dbt_impala/__version__.py
-package_version = "1.5.0"
+package_version = "1.6.0"
 description = """The Impala adapter plugin for dbt"""
 
 dbt_core_version = _get_dbt_core_version()


### PR DESCRIPTION
## Describe your changes
1. Upgrade dbt-core to 1.6
2. Removed support for microseconds datediff micro as Impala doesn't really support microseconds extration from timestamp.
3. Renamed prepare-env to dev_setup in the make file to make it consistent with dbt-hive adapter. 

## Internal Jira ticket number or external issue link
https://jira.cloudera.com/browse/DBT-772

## Testing procedure/screenshots(if appropriate):
https://gist.github.com/vamshikolanu/f6f6800ce24f638d2936addf56101b82

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have formatted my added/modified code to follow pep-8 standards
- [ ] I have checked suggestions from python linter to make sure code is of good quality.
