### PR TITLE
Add kudu support

### DIFF
--- a/dbt/adapters/impala/relation.py
+++ b/dbt/adapters/impala/relation.py
@@ -37,7 +37,7 @@ class ImpalaIncludePolicy(Policy):
 class ImpalaRelation(BaseRelation):
     quote_policy: ImpalaQuotePolicy = field(default_factory=lambda: ImpalaQuotePolicy())
     include_policy: ImpalaIncludePolicy = field(default_factory=lambda: ImpalaIncludePolicy())
-    quote_character: str = None
+    quote_character: str = '`'
     information: str = None
 
     def __post_init__(self):

--- a/dbt/include/impala/macros/adapters.sql
+++ b/dbt/include/impala/macros/adapters.sql
@@ -68,6 +68,14 @@
   {%- endif %}
 {%- endmacro -%}
 
+{% macro ct_option_primary_key(label, required=false) %}
+  {%- set primaryKey = config.get('primary_key', validator=validation[basestring]) -%}
+
+  {%- if primaryKey is not none %}
+    {{label}} {{primaryKey}}
+  {%- endif %}
+{%- endmacro -%}
+
 {% macro ct_option_stored_as(label, required=false) %}
   {%- set storedAs = config.get('stored_as', validator=validation[basestring]) -%}
 
@@ -165,6 +173,7 @@
     {{ ct_option_row_format(label="row format") }}
     {{ ct_option_with_serdeproperties(label="with serdeproperties") }}
     {%- if table_type == 'iceberg' -%} STORED BY ICEBERG {%- endif -%}
+    {{ ct_option_primary_key(label="PRIMARY KEY") }}
     {{ ct_option_stored_as(label="stored as") }}
     {{ ct_option_location_clause(label="location") }}
     {{ ct_option_cached_in(label="cached in") }}


### PR DESCRIPTION
## Describe your changes

Added Kudu support providing the option to set `primary key` when materializing tables (option required by Kudu).

Before this, dbt-impala could only materialize views, but when it came time to create tables, it failed because of the primary key requirements. 

## Internal Jira ticket number or external issue link

## Testing procedure/screenshots(if appropriate):

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have formatted my added/modified code to follow pep-8 standards
- [x] I have checked suggestions from python linter to make sure code is of good quality.
