### PR TITLE
Fix: Change DatabaseException to DbtDatabaseError

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ logs/
 .env
 .venv*
 test.env
+.idea

--- a/dbt/adapters/impala/connections.py
+++ b/dbt/adapters/impala/connections.py
@@ -180,7 +180,7 @@ class ImpalaConnectionManager(SQLConnectionManager):
             )
         except DatabaseError as dbError:
             logger.debug(f"Database connection error: {str(dbError)}")
-            raise dbt.exceptions.DatabaseException("Database Connection error: " + str(dbError))
+            raise dbt.exceptions.DbtDatabaseError("Database Connection error: " + str(dbError))
         except Exception as exc:
             logger.debug(f"Error running SQL: {sql}")
             raise dbt.exceptions.DbtRuntimeError(str(exc))


### PR DESCRIPTION
## Describe your changes

Since dbt-code 1.4.0 and above, the exception DatabaseException changed to DbtDatabaseError.

This leads to errors like `module dbt.exceptions has no attribute DatabaseException` when an actual Database Error happens. 

![Screenshot 2024-09-28 at 10 54 26](https://github.com/user-attachments/assets/ca440a96-880e-48f4-80ff-2a3870950b6d)

dbt-core source code > 1.7.0: https://github.com/dbt-labs/dbt-core/blob/v1.7.0/core/dbt/exceptions.py#L187
dbt-core source code > 1.3.7: https://github.com/dbt-labs/dbt-core/blob/v1.3.7/core/dbt/exceptions.py#L198

## Internal Jira ticket number or external issue link

## Testing procedure/screenshots(if appropriate):

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have formatted my added/modified code to follow pep-8 standards
- [x] I have checked suggestions from python linter to make sure code is of good quality.
