### PR TITLE
DBT-845: Certifying dbt-impala adapter against python 3.12 and python 3.13

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 skipsdist = True
-envlist = py39,py310,py311
+envlist = py310,py311,py312,py313
 
-[testenv:{py39,py310,py311}]
+[testenv:{py310,py311,py312,py313}]
 description = adapter plugin integration and unit testing
 skip_install = true
 passenv =


### PR DESCRIPTION
## Describe your changes
- Verified dbt-impala behaviour in Python 3.12 and Python 3.13 environments. 
- Updated the tox configuration to include Python 3.12 and 3.13.

## Internal Jira ticket number or external issue link
https://cloudera.atlassian.net/browse/DBT-845

## Testing procedure/screenshots(if appropriate):
python 3.12: https://gist.github.com/MonikaK2409/c2e1d48ee29dcd6b451ede3be743f46e
python 3.13: https://gist.github.com/MonikaK2409/e2cdc61ff042ada470434e1e4ca8eb48

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have formatted my added/modified code to follow pep-8 standards
- [x] I have checked suggestions from python linter to make sure code is of good quality.