### PR TITLE
DBT-836: Add support for displaying row count after query execution

### DIFF
--- a/dbt/adapters/impala/connections.py
+++ b/dbt/adapters/impala/connections.py
@@ -335,9 +335,22 @@ class ImpalaConnectionManager(SQLConnectionManager):
         logger.debug(f"IMPALA VERSION {'ImpalaConnectionManager.impala_version'}")
 
     @classmethod
-    def get_response(cls, cursor):
-        message = "OK"
-        return AdapterResponse(_message=message)
+    def get_response(cls, cursor) -> AdapterResponse:
+        modified_rows, _ = cursor._cursor.rowcounts
+
+        rows = modified_rows
+        if rows == -1:
+            if hasattr(cursor._cursor, "_buffer") and cursor._cursor._buffer:
+                rows = len(cursor._cursor._buffer)
+            else:
+                rows = cursor._cursor.rowcount
+
+        if rows is None or rows == -1:
+            message = "OK"
+        else:
+            message = f"OK ({rows} rows)"
+
+        return AdapterResponse(_message=message, rows_affected=rows)
 
     def cancel(self, connection):
         connection.handle.close()

--- a/tests/functional/adapter/test_rowcount.py
+++ b/tests/functional/adapter/test_rowcount.py
@@ -1,0 +1,40 @@
+import pytest
+from dbt.adapters.contracts.connection import AdapterResponse
+
+
+@pytest.mark.usefixtures("project")
+class TestAdapterResponseImpala:
+    def test_select_rowcount_from_buffer(self, adapter):
+        ctas_sql = """
+        create table dbt_test_ctas as
+        select 1 as id union all select 2 as id union all select 3 as id
+        """
+
+        with adapter.connection_named("test_ctas"):
+            response, _ = adapter.execute(ctas_sql, fetch=False)
+
+        assert isinstance(response, AdapterResponse)
+        assert response.rows_affected == 3
+        assert response._message == "OK (3 rows)"
+
+    def test_dml_insert_rows(self, adapter):
+        create_sql = """
+        create table if not exists dbt_test_response_insert (
+            id int
+        )
+        """
+
+        insert_sql = """
+        insert into dbt_test_response_insert values
+        (1),
+        (2)
+        """
+
+        with adapter.connection_named("test_dml"):
+            adapter.execute(create_sql, fetch=False)
+
+            response, _ = adapter.execute(insert_sql, fetch=False)
+
+        assert isinstance(response, AdapterResponse)
+        assert response.rows_affected == 2
+        assert response._message == "OK (2 rows)"


### PR DESCRIPTION
## Describe your changes
- Implemented logic to return row count from the cursor response.
- Added fallback handling for cases where rowcounts returns -1:
    1. Use _buffer length when available (for the cases where results are buffered like in CTAS commands)
    2. Otherwise fall back to cursor.rowcount
- Added test cases to validate row count behaviour for INSERT and CTAS commands.

## Internal Jira ticket number or external issue link
https://cloudera.atlassian.net/browse/DBT-836

## Testing procedure/screenshots(if appropriate):
Test-runs after the change:- https://gist.github.com/MonikaK2409/c23820756338ebcfd291b8fa8de2c50c
dbt runs after the change:- https://gist.github.com/MonikaK2409/5465f308ff351851658bc038a5cc687b

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have formatted my added/modified code to follow pep-8 standards
- [x] I have checked suggestions from python linter to make sure code is of good quality.
