### PR TITLE
Fix Iceberg insert overwrite partition clause

### DIFF
--- a/dbt/include/impala/macros/insertoverwrite.sql
+++ b/dbt/include/impala/macros/insertoverwrite.sql
@@ -17,10 +17,27 @@
 {% macro get_insert_overwrite_sql(target, source, dest_columns) -%}
 
     {% set raw_strategy = config.get('incremental_strategy') or 'append' %}
+    {%- set table_type = config.get('table_type') -%}
     {%- set partition_cols = config.get('partition_by', validator=validation.any[list]) -%}
     {%- set dest_cols_csv = dest_columns | map(attribute="name") | join(", ") -%}
 
-    {% if partition_cols is not none %}
+    {% if table_type == 'iceberg' %}
+
+        {% if raw_strategy == 'insert_overwrite' or raw_strategy == 'microbatch' %}
+
+            insert overwrite {{ target }} ({{ dest_cols_csv }})
+            select {{ dest_cols_csv }}
+            from {{ source }}
+
+        {% elif raw_strategy == 'append' %}
+
+            insert into {{ target }} ({{ dest_cols_csv }})
+            select {{ dest_cols_csv }}
+            from {{ source }}
+
+        {% endif %}
+
+    {% elif partition_cols is not none %}
         {% if partition_cols is string %}
             {%- set partition_cols_csv = partition_cols -%}
         {% else %}

--- a/dbt/include/impala/macros/insertoverwrite.sql
+++ b/dbt/include/impala/macros/insertoverwrite.sql
@@ -21,23 +21,7 @@
     {%- set partition_cols = config.get('partition_by', validator=validation.any[list]) -%}
     {%- set dest_cols_csv = dest_columns | map(attribute="name") | join(", ") -%}
 
-    {% if table_type == 'iceberg' %}
-
-        {% if raw_strategy == 'insert_overwrite' or raw_strategy == 'microbatch' %}
-
-            insert overwrite {{ target }} ({{ dest_cols_csv }})
-            select {{ dest_cols_csv }}
-            from {{ source }}
-
-        {% elif raw_strategy == 'append' %}
-
-            insert into {{ target }} ({{ dest_cols_csv }})
-            select {{ dest_cols_csv }}
-            from {{ source }}
-
-        {% endif %}
-
-    {% elif partition_cols is not none %}
+    {% if partition_cols is not none and table_type != 'iceberg' %}
         {% if partition_cols is string %}
             {%- set partition_cols_csv = partition_cols -%}
         {% else %}
@@ -62,6 +46,12 @@
             )
 
         {% endif %}
+    {% elif table_type == 'iceberg' and (raw_strategy == 'insert_overwrite' or raw_strategy == 'microbatch') %}
+
+        insert overwrite {{ target }} ({{ dest_cols_csv }})
+        select {{ dest_cols_csv }}
+        from {{ source }}
+
     {% else %}
 
         insert into {{ target }} ({{ dest_cols_csv }})

--- a/tests/functional/adapter/test_iceberg_format.py
+++ b/tests/functional/adapter/test_iceberg_format.py
@@ -127,6 +127,21 @@ select *, id as id_partition1 from {{ source('raw', 'seed') }}
 {% endif %}
 """.strip()
 
+insertoverwrite_transform_iceberg_sql = """
+ {{
+    config(
+        materialized="incremental",
+        incremental_strategy="insert_overwrite",
+        partition_by="truncate(3, name)",
+        table_type="iceberg"
+    )
+}}
+select *, id as id_partition1 from {{ source('raw', 'seed') }}
+{% if is_incremental() %}
+    where id > (select max(id) from {{ this }})
+{% endif %}
+""".strip()
+
 
 # For iceberg table formats, check_relations_equal util is not working as expected
 # Impala upstream issue: https://issues.apache.org/jira/browse/IMPALA-12097
@@ -291,5 +306,14 @@ class TestInsertoverwriteIcebergFormatImpala(TestIncrementalIcebergFormatImpala)
     def models(self):
         return {
             "incremental_test_model.sql": insertoverwrite_iceberg_sql,
+            "schema.yml": schema_base_yml,
+        }
+
+
+class TestInsertoverwriteTransformIcebergFormatImpala(TestIncrementalIcebergFormatImpala):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "incremental_test_model.sql": insertoverwrite_transform_iceberg_sql,
             "schema.yml": schema_base_yml,
         }

--- a/tests/functional/adapter/test_iceberg_v2_format.py
+++ b/tests/functional/adapter/test_iceberg_v2_format.py
@@ -109,6 +109,22 @@ select *, id as id_partition1 from {{ source('raw', 'seed') }}
 {% endif %}
 """.strip()
 
+insertoverwrite_transform_iceberg_sql = """
+ {{
+    config(
+        materialized="incremental",
+        incremental_strategy="insert_overwrite",
+        partition_by="truncate(3, name)",
+        table_type="iceberg",
+        tbl_properties="('format-version'='2')"
+    )
+}}
+select *, id as id_partition1 from {{ source('raw', 'seed') }}
+{% if is_incremental() %}
+    where id > (select max(id) from {{ this }})
+{% endif %}
+""".strip()
+
 
 # For iceberg table formats, check_relations_equal util is not working as expected
 # Impala upstream issue: https://issues.apache.org/jira/browse/IMPALA-12097
@@ -158,5 +174,14 @@ class TestInsertoverwriteIcebergV2FormatImpala(TestIncrementalIcebergFormatImpal
     def models(self):
         return {
             "incremental_test_model.sql": insertoverwrite_iceberg_sql,
+            "schema.yml": schema_base_yml,
+        }
+
+
+class TestInsertoverwriteTransformIcebergV2FormatImpala(TestIncrementalIcebergFormatImpala):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "incremental_test_model.sql": insertoverwrite_transform_iceberg_sql,
             "schema.yml": schema_base_yml,
         }


### PR DESCRIPTION
## Summary

Fixes #204.

Iceberg uses hidden partitioning, so incremental `insert_overwrite` should not generate an `INSERT ... PARTITION(...)` clause for Iceberg tables. This updates `get_insert_overwrite_sql` to omit the partition clause when `table_type="iceberg"` while preserving existing partitioned insert behavior for non-Iceberg tables.

Adds regression coverage for Iceberg v1 and v2 tables using a partition transform.

## Testing

- `git diff --check`
- `PYTHONPYCACHEPREFIX=/tmp/dbt-impala-pycache python3 -m py_compile tests/functional/adapter/test_iceberg_format.py tests/functional/adapter/test_iceberg_v2_format.py`
- `/tmp/dbt-impala-venv/bin/python -m pytest tests/unit`
- `/tmp/dbt-impala-venv/bin/python -m pytest tests/functional/adapter/test_iceberg_format.py tests/functional/adapter/test_iceberg_v2_format.py -k Insertoverwrite --collect-only`

Manual smoke against Kerberos-enabled Impala on Kubernetes:

- `dbt seed`
- initial `dbt run` created an Iceberg table with `PARTITIONED BY SPEC (truncate(3, name))`
- second `dbt run` completed incremental `insert_overwrite`
- runtime SQL used `insert overwrite dbt_issue204.incremental_test_model (id, name, some_date, id_partition1)` without `partition(...)`
- final row count: `20`

Temporary smoke schema was dropped after validation.

Assisted-by: Codex GPT5.5
