### PR TITLE
DBT-791: Removing the describe table statement and rather use the show queries

### DIFF
--- a/dbt/adapters/impala/impl.py
+++ b/dbt/adapters/impala/impl.py
@@ -112,9 +112,13 @@ class ImpalaAdapter(SQLAdapter):
     def list_relations_without_caching(
         self, schema_relation: ImpalaRelation
     ) -> List[ImpalaRelation]:
+        kwargs = {"schema": schema_relation}
+
         try:
-            kwargs = {"relation": schema_relation}
-            table_relations = self.execute_macro(LIST_TABLES_IN_RELATION_MACRO_NAME, kwargs=kwargs)
+            result_tables = self.execute_macro(
+                "impala__list_tables_without_caching", kwargs=kwargs
+            )
+            result_views = self.execute_macro("impala__list_views_without_caching", kwargs=kwargs)
         except dbt.exceptions.DbtRuntimeError as e:
             errmsg = getattr(e, "msg", "")
             if f"Database does not exist" in errmsg:
@@ -123,19 +127,32 @@ class ImpalaAdapter(SQLAdapter):
                 logger.error(f"Unable to extract tables in relation {schema_relation}: {errmsg}")
                 raise e
 
-        relations = []
-        for table_relation in table_relations:
-            _rel_type = self.fetch_relation_type(table_relation)
-            _identifier = table_relation.identifier
+        result_tables_without_view = []
+        for row in result_tables:
+            # check if this table is view
+            is_view = len(list(filter(lambda x: x["name"] == row["name"], result_views))) == 1
+            if not is_view:
+                result_tables_without_view.append(row)
 
-            relation = self.Relation.create(
-                database=None,
-                schema=schema_relation.schema,
-                identifier=_identifier,
-                type=_rel_type,
-                information=_identifier,
+        relations = []
+
+        for row in result_tables_without_view:
+            relations.append(
+                self.Relation.create(
+                    schema=schema_relation.schema,
+                    identifier=row["name"],
+                    type="table",
+                )
             )
-            relations.append(relation)
+
+        for row in result_views:
+            relations.append(
+                self.Relation.create(
+                    schema=schema_relation.schema,
+                    identifier=row["name"],
+                    type="view",
+                )
+            )
 
         return relations
 

--- a/dbt/include/impala/macros/adapters.sql
+++ b/dbt/include/impala/macros/adapters.sql
@@ -156,25 +156,18 @@
   {{ return(tables) }}
 {% endmacro %}
 
+{% macro impala__list_tables_without_caching(schema) %}
+  {% call statement('list_tables_without_caching', fetch_result=True) -%}
+    show tables in {{ schema }}
+  {% endcall %}
+  {% do return(load_result('list_tables_without_caching').table) %}
+{% endmacro %}
 
-{# Note: This function currently needs to query each object to determine its type. Depending on the schema, this function could be expensive. #}
-{% macro impala__list_relations_without_caching(relation) %}
-  {% set result_set = run_query('show tables in ' ~ relation) %}
-  {% set objects_with_type = [] %}
-
-  {%- for rs in result_set -%}
-    {% set obj_type = [] %}
-
-    {% do obj_type.append(rs[0]) %}
-
-    {% set obj_rel = relation.new_copy(relation.schema, rs[0]) %}
-    {% set rel_type = get_relation_type(obj_rel) %}
-    {% do obj_type.append(rel_type) %}
-
-    {% do objects_with_type.append(obj_type) %}
-  {%- endfor -%}
-
-  {{ return(objects_with_type) }}
+{% macro impala__list_views_without_caching(schema) %}
+  {% call statement('list_views_without_caching', fetch_result=True) -%}
+    show views  in {{ schema }}
+  {% endcall %}
+  {% do return(load_result('list_views_without_caching').table) %}
 {% endmacro %}
 
 {% macro impala__create_table_as(temporary, relation, sql) -%}


### PR DESCRIPTION
## Describe your changes
dbt-impala adapter loops through all schemas specified in dbt-project.yml and executes an expensive DESCRIBE TABLE EXTENDED <table_name> query for every single table in the schema.

In larger environments, executing these queries sequentially in a loop introduces overhead. Hence instead of using a describe command, show tables/show view command is executed to extract the metadata.

## Internal Jira ticket number or external issue link
https://cloudera.atlassian.net/browse/DBT-791

## Testing procedure/screenshots(if appropriate):
Performance report:- https://gist.github.com/MonikaK2409/9abc50a4d68303b4ba14c13333ae348e
Test runs:- https://gist.github.com/MonikaK2409/52a8d73232feae046e2713beb8fad131

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have formatted my added/modified code to follow pep-8 standards
- [x] I have checked suggestions from python linter to make sure code is of good quality.
