### PR TITLE
DBT-856: Added persist_doc support in dbt-impala

### DIFF
--- a/dbt/adapters/impala/column.py
+++ b/dbt/adapters/impala/column.py
@@ -30,6 +30,8 @@ class ImpalaColumn(dbtClassMixin, Column):
     table_owner: Optional[str] = None
     table_stats: Optional[Dict[str, Any]] = None
     column_index: Optional[int] = None
+    comment: Optional[str] = None
+    table_comment: Optional[str] = None
 
     @classmethod
     def translate_type(cls, dtype: str) -> str:

--- a/dbt/adapters/impala/impl.py
+++ b/dbt/adapters/impala/impl.py
@@ -218,15 +218,34 @@ class ImpalaAdapter(SQLAdapter):
             for row in raw_rows[0:column_separator_pos]
             if not row["name"].startswith("#") and not row["name"] == ""
         ]
-        # trim the fields so that these are clean key,value pairs and metadata.get() correctly returns the values
-        metadata = {
-            col["name"].split(":")[0].strip(): col["type"].strip()
-            for col in raw_rows[table_separator_pos + 1 :]
-            if col["name"]
-            and not col["name"].startswith("#")
-            and not col["name"] == ""
-            and col["type"]
-        }
+
+        # Build metadata from DESCRIBE EXTENDED detail rows.
+        # Impala/Hive may put values in `type` OR `comment`, and table properties often appear as continuous rows with an empty `name`.
+        metadata: Dict[str, str] = {}
+        for col in raw_rows[table_separator_pos + 1 :]:
+            col_dict = dict(zip(col._keys, col._values))
+            name = (col_dict.get("name") or "").strip()
+            if name.startswith("#"):
+                continue
+
+            type_val = (col_dict.get("type") or "").strip()
+            comment_val = (col_dict.get("comment") or "").strip()
+
+            if name:
+                key = name.split(":")[0].strip()
+                if not key:
+                    continue
+                value = type_val or comment_val
+            else:
+                key = type_val
+                value = comment_val
+
+            if not key or not value:
+                continue
+            if value.upper() == "NULL":
+                continue
+
+            metadata[key] = value
 
         raw_table_stats = metadata.get(KEY_TABLE_STATISTICS)
         table_stats = ImpalaColumn.convert_table_stats(raw_table_stats)
@@ -242,6 +261,8 @@ class ImpalaAdapter(SQLAdapter):
                 column=column["name"],
                 column_index=idx,
                 dtype=column["type"],
+                comment=column.get("comment"),
+                table_comment=metadata.get("comment"),
             )
             for idx, column in enumerate(rows)
         ]
@@ -343,6 +364,8 @@ class ImpalaAdapter(SQLAdapter):
             as_dict["column_name"] = as_dict.pop("column", None)
             as_dict["column_type"] = as_dict.pop("dtype")
             as_dict["table_database"] = None
+            as_dict["column_comment"] = column.comment
+            as_dict["table_comment"] = column.table_comment
 
             yield as_dict
 

--- a/dbt/include/impala/macros/adapters.sql
+++ b/dbt/include/impala/macros/adapters.sql
@@ -239,6 +239,57 @@
   {% endcall %}
 {% endmacro %}
 
+{# Escape single quotes and truncate comments to 256 characters, as Impala has a limit. #}
+{% macro impala__truncate_and_escape_comment(comment, max_length=256) -%}
+  {%- if not comment -%}
+    {{ return(none) }}
+  {%- endif -%}
+
+  {%- set escaped_comment = comment | replace("'", "\\'") -%}
+
+  {%- if escaped_comment | length > max_length -%}
+    {%- do exceptions.warn("Impala comments are limited to " ~ max_length ~ " characters. Truncating comment for " ~ this) -%}
+    {{ return(escaped_comment[:max_length]) }}
+  {%- else -%}
+    {{ return(escaped_comment) }}
+  {%- endif -%}
+{%- endmacro %}
+
+{% macro impala__persist_docs(relation, model, for_relation, for_columns) -%}
+  {%- if for_relation and config.persist_relation_docs() and model.description -%}
+    {%- do impala__alter_relation_comment(relation, model.description) -%}
+  {%- endif -%}
+
+  {%- if for_columns and config.persist_column_docs() and model.columns -%}
+    {%- set existing_columns = adapter.get_columns_in_relation(relation) | map(attribute="name") | list -%}
+    {%- set filtered_columns = validate_doc_columns(relation, model.columns, existing_columns) -%}
+    {%- do impala__alter_column_comment(relation, filtered_columns) -%}
+  {%- endif -%}
+{%- endmacro %}
+
+{% macro impala__alter_relation_comment(relation, relation_comment) -%}
+  {% set escaped_comment = impala__truncate_and_escape_comment(relation_comment) %}
+  {% if escaped_comment %}
+    {% set object_type = 'view' if relation.type == 'view' else 'table' %}
+    {% call statement('alter_relation_comment') %}
+        comment on {{ object_type }} {{ relation }} is '{{ escaped_comment }}'
+    {% endcall %}
+  {% endif %}
+{%- endmacro %}
+
+{% macro impala__alter_column_comment(relation, column_dict) -%}
+  {% for column_name, column_info in column_dict.items() %}
+    {% set comment = column_info.get('description') %}
+    {% set escaped_comment = impala__truncate_and_escape_comment(comment) %}
+    {% if escaped_comment %}
+      {% set quoted_column = adapter.quote(column_name) if column_info.get('quote') else column_name %}
+      {% call statement('alter_column_comment_' ~ column_name) %}
+            comment on column {{ relation }}.{{ quoted_column }} is '{{ escaped_comment }}'
+      {% endcall %}
+    {% endif %}
+  {% endfor %}
+{%- endmacro %}
+
 {% macro is_relation_present(relation) -%}
   {% set result_set = run_query('show tables in ' ~ relation.schema ~ ' like "' ~ relation.identifier.lower() ~ '"') %}
 

--- a/tests/functional/adapter/test_persist_docs.py
+++ b/tests/functional/adapter/test_persist_docs.py
@@ -1,0 +1,27 @@
+from dbt.tests.util import run_dbt
+from dbt.tests.adapter.persist_docs.test_persist_docs import (
+    BasePersistDocs,
+    BasePersistDocsColumnMissing,
+    BasePersistDocsCommentOnQuotedColumn,
+)
+
+
+class TestPersistDocsImpala(BasePersistDocs):
+    def _assert_common_comments(self, *comments):
+        for comment in comments:
+            assert comment is not None
+            assert "with double quotes" in comment
+            assert "abc123" in comment
+            assert "/* comment */" in comment
+            if "\n" in comment:
+                pass
+            else:
+                assert "statistics are made up" in comment or "reserved -- characters" in comment
+
+
+class TestPersistDocsColumnMissingImpala(BasePersistDocsColumnMissing):
+    pass
+
+
+class TestPersistDocsCommentOnQuotedColumnImpala(BasePersistDocsCommentOnQuotedColumn):
+    pass


### PR DESCRIPTION
## Describe your changes
This change adds support for dbt’s persist_docs feature on the Impala adapter. Model and column descriptions from schema.yml are written to the warehouse using Impala’s COMMENT ON syntax after models are built.
- Added impala__persist_docs to persist relation and column descriptions when persist_docs is enabled.
- Added impala__alter_relation_comment using COMMENT ON TABLE / COMMENT ON VIEW
- Added impala__alter_column_comment using COMMENT ON COLUMN.
- Added impala__truncate_and_escape_comment to escape single quotes for SQL (' → \') and truncate comments to Impala’s 256-character limit.
- Extended ImpalaColumn with comment and table_comment fields.
- Updated DESCRIBE FORMATTED parsing to read column and table comments from Impala metadata.

## Internal Jira ticket number or external issue link
https://cloudera.atlassian.net/browse/DBT-856

## Testing procedure/screenshots(if appropriate):
https://gist.github.com/MonikaK2409/3744a1ee186a2275b0d94b06fc6e5acb

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have formatted my added/modified code to follow pep-8 standards
- [x] I have checked suggestions from python linter to make sure code is of good quality.